### PR TITLE
Adding themes to all CW Forms (updated)

### DIFF
--- a/AboutForm.Designer.cs
+++ b/AboutForm.Designer.cs
@@ -37,7 +37,7 @@
             // OkButton
             // 
             this.OkButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.OkButton.Location = new System.Drawing.Point(305, 147);
+            this.OkButton.Location = new System.Drawing.Point(338, 165);
             this.OkButton.Name = "OkButton";
             this.OkButton.Size = new System.Drawing.Size(75, 23);
             this.OkButton.TabIndex = 0;
@@ -52,7 +52,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label1.Location = new System.Drawing.Point(12, 35);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(368, 138);
+            this.label1.Size = new System.Drawing.Size(401, 156);
             this.label1.TabIndex = 1;
             this.label1.Text = resources.GetString("label1.Text");
             this.label1.TextAlign = System.Drawing.ContentAlignment.TopCenter;
@@ -64,7 +64,7 @@
             this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label2.Location = new System.Drawing.Point(12, 9);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(368, 26);
+            this.label2.Size = new System.Drawing.Size(401, 26);
             this.label2.TabIndex = 2;
             this.label2.Text = "CodeWalker by dexyfex";
             this.label2.TextAlign = System.Drawing.ContentAlignment.TopCenter;
@@ -73,7 +73,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(392, 182);
+            this.ClientSize = new System.Drawing.Size(425, 200);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.OkButton);
             this.Controls.Add(this.label1);

--- a/AboutForm.resx
+++ b/AboutForm.resx
@@ -125,7 +125,8 @@ Special thanks to:
 --  Neodymium  --  tgascoigne  -- CamxxCore --
 --  Tadden  --  Gramz  --  Kai  --  Vertigo  --  HL  --  Pouaichh  --
 -- Dilapidated -- dav90 -- Neos7 -- Jevi -- sollaholla --
--- The .White team  --  CP  --  Kilian  --  PNWParksFan  --</value>
+-- The .White team  --  CP  --  Kilian  --  PNWParksFan  --
+-- Skylumz -- </value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/CodeWalker.WinForms/CodeWalker.WinForms.csproj
+++ b/CodeWalker.WinForms/CodeWalker.WinForms.csproj
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FastColoredTextBox">
+      <HintPath>..\..\..\Mods\Map Mod programs\CodeWalker29_dev5\FastColoredTextBox.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/CodeWalker.WinForms/FormUtils.cs
+++ b/CodeWalker.WinForms/FormUtils.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using CodeWalker.WinForms;
+using FastColoredTextBoxNS;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
@@ -233,7 +235,7 @@ namespace CodeWalker
     public static class Prompt
     {
         //handy utility to get a string from the user...
-        public static string ShowDialog(IWin32Window owner, string text, string caption, string defaultvalue = "")
+        public static string ShowDialog(IWin32Window owner, string text, string caption, ThemeBase Theme, string defaultvalue = "")
         {
             Form prompt = new Form()
             {
@@ -245,6 +247,7 @@ namespace CodeWalker
                 MaximizeBox = false,
                 MinimizeBox = false
             };
+            FormTheme.SetTheme(prompt, Theme);
             var textLabel = new Label() { Left = 30, Top = 20, Width = 370, Height = 20, Text = text, };
             var textBox = new TextBox() { Left = 30, Top = 40, Width = 370, Text = defaultvalue };
             var cancel = new Button() { Text = "Cancel", Left = 230, Width = 80, Top = 70, DialogResult = DialogResult.Cancel };
@@ -275,6 +278,10 @@ namespace CodeWalker
             var disback = SystemColors.Control;
             var disfore = form.ForeColor;
             var btnback = Color.Transparent;
+            var fStyle = FlatStyle.System;
+            var panelC = SystemColors.Control;
+            var dropdwn = SystemColors.Control;
+            var dropdwntxt = form.ForeColor;
 
             if (theme is VS2015DarkTheme)
             {
@@ -285,6 +292,10 @@ namespace CodeWalker
                 disback = form.BackColor;// Color.FromArgb(32,32,32);
                 disfore = Color.DarkGray;
                 btnback = form.BackColor;
+                fStyle = FlatStyle.Flat;
+                panelC = form.BackColor;
+                dropdwn = form.BackColor;
+                dropdwntxt = form.ForeColor;
             }
 
             var allcontrols = new List<Control>();
@@ -324,7 +335,45 @@ namespace CodeWalker
                     c.BackColor = wndback;
                     (c as TreeView).LineColor = form.ForeColor;
                 }
+                else if (c is Panel)
+                {
+                    c.BackColor = panelC;
+                }
+                else if (c is TrackBar)
+                {
+                    c.BackColor = form.BackColor;
+                }
+                else if (c is ReadOnlyPropertyGrid)
+                {
+                    var rpd = (ReadOnlyPropertyGrid)c;
+                    rpd.ViewBackColor = form.BackColor;
+                    rpd.ViewForeColor = form.ForeColor;
+                }
+                else if (c is PropertyGridFix)
+                {
+                    var rpd = (PropertyGridFix)c;
+                    rpd.ViewBackColor = form.BackColor;
+                    rpd.ViewForeColor = form.ForeColor;
+                }
+                else if (c is ComboBox)
+                {
+                    var cb = (ComboBox)c;
 
+                    cb.BackColor = dropdwn;
+                    cb.FlatStyle = fStyle;
+                    cb.ForeColor = dropdwntxt;
+                }
+                else if (c is ContextMenuStrip)
+                {
+                    c.BackColor = form.BackColor;
+                    c.ForeColor = form.ForeColor;
+                }
+                else if (c is FastColoredTextBox)
+                {
+                    var fctb = (FastColoredTextBox)c;
+                    fctb.BackColor = form.BackColor;
+                    fctb.IndentBackColor = form.BackColor;
+                }
             }
 
         }

--- a/ExploreForm.cs
+++ b/ExploreForm.cs
@@ -1442,6 +1442,7 @@ namespace CodeWalker
         private void ViewHex(string name, string path, byte[] data)
         {
             HexForm f = new HexForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadData(name, path, data);
         }
@@ -1449,6 +1450,7 @@ namespace CodeWalker
         {
             string xml = Encoding.UTF8.GetString(data);
             XmlForm f = new XmlForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadXml(name, path, xml);
         }
@@ -1456,6 +1458,7 @@ namespace CodeWalker
         {
             string txt = Encoding.UTF8.GetString(data);
             TextForm f = new TextForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadText(name, path, txt);
         }
@@ -1463,6 +1466,7 @@ namespace CodeWalker
         {
             var ytd = RpfFile.GetFile<YtdFile>(e, data);
             YtdForm f = new YtdForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadYtd(ytd);
         }
@@ -1470,6 +1474,7 @@ namespace CodeWalker
         {
             var ymt = RpfFile.GetFile<YmtFile>(e, data);
             MetaForm f = new MetaForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadMeta(ymt);
         }
@@ -1477,6 +1482,7 @@ namespace CodeWalker
         {
             var ymf = RpfFile.GetFile<YmfFile>(e, data);
             MetaForm f = new MetaForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadMeta(ymf);
         }
@@ -1484,6 +1490,7 @@ namespace CodeWalker
         {
             var ymap = RpfFile.GetFile<YmapFile>(e, data);
             MetaForm f = new MetaForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadMeta(ymap);
         }
@@ -1491,6 +1498,7 @@ namespace CodeWalker
         {
             var ytyp = RpfFile.GetFile<YtypFile>(e, data);
             MetaForm f = new MetaForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadMeta(ytyp);
         }
@@ -1498,6 +1506,7 @@ namespace CodeWalker
         {
             var pso = RpfFile.GetFile<JPsoFile>(e, data);
             MetaForm f = new MetaForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadMeta(pso);
         }
@@ -1506,6 +1515,7 @@ namespace CodeWalker
             var nl = e?.NameLower ?? "";
             var fe = Path.GetExtension(nl);
             ModelForm f = new ModelForm(this);
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             switch (fe)
             {
@@ -1539,6 +1549,7 @@ namespace CodeWalker
         {
             var cut = RpfFile.GetFile<CutFile>(e, data);
             MetaForm f = new MetaForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadMeta(cut);
         }
@@ -1546,6 +1557,7 @@ namespace CodeWalker
         {
             var awc = RpfFile.GetFile<AwcFile>(e, data);
             AwcForm f = new AwcForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadAwc(awc);
         }
@@ -1553,6 +1565,7 @@ namespace CodeWalker
         {
             var gxt = RpfFile.GetFile<Gxt2File>(e, data);
             GxtForm f = new GxtForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadGxt2(gxt);
         }
@@ -1560,6 +1573,7 @@ namespace CodeWalker
         {
             var rel = RpfFile.GetFile<RelFile>(e, data);
             RelForm f = new RelForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadRel(rel);
         }
@@ -1567,6 +1581,7 @@ namespace CodeWalker
         {
             var fxc = RpfFile.GetFile<FxcFile>(e, data);
             FxcForm f = new FxcForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadFxc(fxc);
         }
@@ -1574,6 +1589,7 @@ namespace CodeWalker
         {
             var ywr = RpfFile.GetFile<YwrFile>(e, data);
             YwrForm f = new YwrForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadYwr(ywr);
         }
@@ -1581,6 +1597,7 @@ namespace CodeWalker
         {
             var yvr = RpfFile.GetFile<YvrFile>(e, data);
             YvrForm f = new YvrForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadYvr(yvr);
         }
@@ -1588,6 +1605,7 @@ namespace CodeWalker
         {
             var ycd = RpfFile.GetFile<YcdFile>(e, data);
             YcdForm f = new YcdForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadYcd(ycd);
         }
@@ -1595,6 +1613,7 @@ namespace CodeWalker
         {
             var cachedat = RpfFile.GetFile<CacheDatFile>(e, data);
             MetaForm f = new MetaForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show();
             f.LoadMeta(cachedat);
         }
@@ -2071,7 +2090,7 @@ namespace CodeWalker
             if (CurrentFolder == null) return;//shouldn't happen
             if (CurrentFolder?.IsSearchResults ?? false) return;
 
-            string fname = Prompt.ShowDialog(this, "Enter a name for the new folder:", "Create folder", "folder");
+            string fname = Prompt.ShowDialog(this, "Enter a name for the new folder:", "Create folder", Theme, "folder");
             if (string.IsNullOrEmpty(fname))
             {
                 return;//no name was provided.
@@ -2128,7 +2147,7 @@ namespace CodeWalker
             if (CurrentFolder == null) return;//shouldn't happen
             if (CurrentFolder?.IsSearchResults ?? false) return;
 
-            string fname = Prompt.ShowDialog(this, "Enter a name for the new archive:", "Create RPF7 archive", "new");
+            string fname = Prompt.ShowDialog(this, "Enter a name for the new archive:", "Create RPF7 archive", Theme, "new");
             if (string.IsNullOrEmpty(fname))
             {
                 return;//no name was provided.
@@ -2466,7 +2485,7 @@ namespace CodeWalker
             if ((CurrentFiles != null) && (CurrentFiles.Count > idx))
             {
                 var item = CurrentFiles[idx];
-                string newname = Prompt.ShowDialog(this, "Enter the new name for this item:", "Rename item", item.Name);
+                string newname = Prompt.ShowDialog(this, "Enter the new name for this item:", "Rename item", Theme, item.Name);
                 if (!string.IsNullOrEmpty(newname))
                 {
                     RenameItem(item, newname);

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -734,5 +734,20 @@ namespace CodeWalker.Properties {
                 this["ExplorerWindowTheme"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Windows")]
+        public string WorldWindowTheme
+        {
+            get
+            {
+                return ((string)(this["WorldWindowTheme"]));
+            }
+            set
+            {
+                this["WorldWindowTheme"] = value;
+            }
+        }
     }
 }

--- a/WorldForm.Designer.cs
+++ b/WorldForm.Designer.cs
@@ -284,6 +284,9 @@ namespace CodeWalker
             this.ToolbarCameraMapViewButton = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolbarCameraOrthographicButton = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolbarPanel = new System.Windows.Forms.Panel();
+            this.VSExtender = new WeifenLuo.WinFormsUI.Docking.VisualStudioToolStripExtender(this.components);
+            this.ThemeComboBox = new System.Windows.Forms.ComboBox();
+            this.label31 = new System.Windows.Forms.Label();
             this.StatusStrip.SuspendLayout();
             this.ToolsPanel.SuspendLayout();
             this.ToolsTabControl.SuspendLayout();
@@ -344,7 +347,7 @@ namespace CodeWalker
             this.StatusLabel.BackColor = System.Drawing.SystemColors.Control;
             this.StatusLabel.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.StatusLabel.Name = "StatusLabel";
-            this.StatusLabel.Size = new System.Drawing.Size(878, 17);
+            this.StatusLabel.Size = new System.Drawing.Size(864, 17);
             this.StatusLabel.Spring = true;
             this.StatusLabel.Text = "Initialising";
             this.StatusLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -353,14 +356,14 @@ namespace CodeWalker
             // 
             this.MousedLabel.BackColor = System.Drawing.SystemColors.Control;
             this.MousedLabel.Name = "MousedLabel";
-            this.MousedLabel.Size = new System.Drawing.Size(16, 17);
+            this.MousedLabel.Size = new System.Drawing.Size(20, 17);
             this.MousedLabel.Text = "   ";
             // 
             // StatsLabel
             // 
             this.StatsLabel.BackColor = System.Drawing.SystemColors.Control;
             this.StatsLabel.Name = "StatsLabel";
-            this.StatsLabel.Size = new System.Drawing.Size(75, 17);
+            this.StatsLabel.Size = new System.Drawing.Size(85, 17);
             this.StatsLabel.Text = "0 geometries";
             // 
             // ModelComboBox
@@ -544,7 +547,7 @@ namespace CodeWalker
             this.EnableModsCheckBox.Enabled = false;
             this.EnableModsCheckBox.Location = new System.Drawing.Point(6, 280);
             this.EnableModsCheckBox.Name = "EnableModsCheckBox";
-            this.EnableModsCheckBox.Size = new System.Drawing.Size(88, 17);
+            this.EnableModsCheckBox.Size = new System.Drawing.Size(99, 19);
             this.EnableModsCheckBox.TabIndex = 68;
             this.EnableModsCheckBox.Text = "Enable Mods";
             this.EnableModsCheckBox.UseVisualStyleBackColor = true;
@@ -555,7 +558,7 @@ namespace CodeWalker
             this.label30.AutoSize = true;
             this.label30.Location = new System.Drawing.Point(1, 337);
             this.label30.Name = "label30";
-            this.label30.Size = new System.Drawing.Size(60, 13);
+            this.label30.Size = new System.Drawing.Size(66, 15);
             this.label30.TabIndex = 70;
             this.label30.Text = "DLC Level:";
             // 
@@ -579,7 +582,7 @@ namespace CodeWalker
             this.EnableDlcCheckBox.Enabled = false;
             this.EnableDlcCheckBox.Location = new System.Drawing.Point(6, 311);
             this.EnableDlcCheckBox.Name = "EnableDlcCheckBox";
-            this.EnableDlcCheckBox.Size = new System.Drawing.Size(83, 17);
+            this.EnableDlcCheckBox.Size = new System.Drawing.Size(92, 19);
             this.EnableDlcCheckBox.TabIndex = 69;
             this.EnableDlcCheckBox.Text = "Enable DLC";
             this.EnableDlcCheckBox.UseVisualStyleBackColor = true;
@@ -592,7 +595,7 @@ namespace CodeWalker
             this.WorldYmapWeatherFilterCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.WorldYmapWeatherFilterCheckBox.Location = new System.Drawing.Point(6, 237);
             this.WorldYmapWeatherFilterCheckBox.Name = "WorldYmapWeatherFilterCheckBox";
-            this.WorldYmapWeatherFilterCheckBox.Size = new System.Drawing.Size(136, 17);
+            this.WorldYmapWeatherFilterCheckBox.Size = new System.Drawing.Size(154, 19);
             this.WorldYmapWeatherFilterCheckBox.TabIndex = 67;
             this.WorldYmapWeatherFilterCheckBox.Text = "Filter ymaps by weather";
             this.WorldYmapWeatherFilterCheckBox.UseVisualStyleBackColor = true;
@@ -605,7 +608,7 @@ namespace CodeWalker
             this.WorldYmapTimeFilterCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.WorldYmapTimeFilterCheckBox.Location = new System.Drawing.Point(6, 214);
             this.WorldYmapTimeFilterCheckBox.Name = "WorldYmapTimeFilterCheckBox";
-            this.WorldYmapTimeFilterCheckBox.Size = new System.Drawing.Size(149, 17);
+            this.WorldYmapTimeFilterCheckBox.Size = new System.Drawing.Size(169, 19);
             this.WorldYmapTimeFilterCheckBox.TabIndex = 66;
             this.WorldYmapTimeFilterCheckBox.Text = "Filter ymaps by time of day";
             this.WorldYmapTimeFilterCheckBox.UseVisualStyleBackColor = true;
@@ -618,7 +621,7 @@ namespace CodeWalker
             this.WorldScriptedYmapsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.WorldScriptedYmapsCheckBox.Location = new System.Drawing.Point(6, 182);
             this.WorldScriptedYmapsCheckBox.Name = "WorldScriptedYmapsCheckBox";
-            this.WorldScriptedYmapsCheckBox.Size = new System.Drawing.Size(126, 17);
+            this.WorldScriptedYmapsCheckBox.Size = new System.Drawing.Size(142, 19);
             this.WorldScriptedYmapsCheckBox.TabIndex = 65;
             this.WorldScriptedYmapsCheckBox.Text = "Show scripted ymaps";
             this.WorldScriptedYmapsCheckBox.UseVisualStyleBackColor = true;
@@ -629,7 +632,7 @@ namespace CodeWalker
             this.WorldDetailDistLabel.AutoSize = true;
             this.WorldDetailDistLabel.Location = new System.Drawing.Point(87, 94);
             this.WorldDetailDistLabel.Name = "WorldDetailDistLabel";
-            this.WorldDetailDistLabel.Size = new System.Drawing.Size(22, 13);
+            this.WorldDetailDistLabel.Size = new System.Drawing.Size(24, 15);
             this.WorldDetailDistLabel.TabIndex = 64;
             this.WorldDetailDistLabel.Text = "1.0";
             // 
@@ -638,7 +641,7 @@ namespace CodeWalker
             this.label18.AutoSize = true;
             this.label18.Location = new System.Drawing.Point(1, 94);
             this.label18.Name = "label18";
-            this.label18.Size = new System.Drawing.Size(80, 13);
+            this.label18.Size = new System.Drawing.Size(91, 15);
             this.label18.TabIndex = 63;
             this.label18.Text = "Detail distance:";
             // 
@@ -662,7 +665,7 @@ namespace CodeWalker
             this.WorldLodDistLabel.AutoSize = true;
             this.WorldLodDistLabel.Location = new System.Drawing.Point(82, 39);
             this.WorldLodDistLabel.Name = "WorldLodDistLabel";
-            this.WorldLodDistLabel.Size = new System.Drawing.Size(22, 13);
+            this.WorldLodDistLabel.Size = new System.Drawing.Size(24, 15);
             this.WorldLodDistLabel.TabIndex = 61;
             this.WorldLodDistLabel.Text = "1.0";
             this.WorldLodDistLabel.Visible = false;
@@ -672,7 +675,7 @@ namespace CodeWalker
             this.label16.AutoSize = true;
             this.label16.Location = new System.Drawing.Point(1, 39);
             this.label16.Name = "label16";
-            this.label16.Size = new System.Drawing.Size(75, 13);
+            this.label16.Size = new System.Drawing.Size(84, 15);
             this.label16.TabIndex = 60;
             this.label16.Text = "LOD distance:";
             this.label16.Visible = false;
@@ -698,7 +701,7 @@ namespace CodeWalker
             this.label15.AutoSize = true;
             this.label15.Location = new System.Drawing.Point(1, 9);
             this.label15.Name = "label15";
-            this.label15.Size = new System.Drawing.Size(55, 13);
+            this.label15.Size = new System.Drawing.Size(62, 15);
             this.label15.TabIndex = 58;
             this.label15.Text = "Max LOD:";
             // 
@@ -742,7 +745,7 @@ namespace CodeWalker
             this.ShowYmapChildrenCheckBox.Enabled = false;
             this.ShowYmapChildrenCheckBox.Location = new System.Drawing.Point(6, 59);
             this.ShowYmapChildrenCheckBox.Name = "ShowYmapChildrenCheckBox";
-            this.ShowYmapChildrenCheckBox.Size = new System.Drawing.Size(93, 17);
+            this.ShowYmapChildrenCheckBox.Size = new System.Drawing.Size(104, 19);
             this.ShowYmapChildrenCheckBox.TabIndex = 35;
             this.ShowYmapChildrenCheckBox.Text = "Show children";
             this.ShowYmapChildrenCheckBox.UseVisualStyleBackColor = true;
@@ -753,7 +756,7 @@ namespace CodeWalker
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(3, 88);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(77, 13);
+            this.label2.Size = new System.Drawing.Size(88, 15);
             this.label2.TabIndex = 8;
             this.label2.Text = "Ymaps to load:";
             // 
@@ -777,7 +780,7 @@ namespace CodeWalker
             this.DynamicLODCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.DynamicLODCheckBox.Location = new System.Drawing.Point(6, 6);
             this.DynamicLODCheckBox.Name = "DynamicLODCheckBox";
-            this.DynamicLODCheckBox.Size = new System.Drawing.Size(92, 17);
+            this.DynamicLODCheckBox.Size = new System.Drawing.Size(102, 19);
             this.DynamicLODCheckBox.TabIndex = 33;
             this.DynamicLODCheckBox.Text = "Dynamic LOD";
             this.DynamicLODCheckBox.UseVisualStyleBackColor = true;
@@ -813,7 +816,7 @@ namespace CodeWalker
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(-1, 10);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(39, 13);
+            this.label1.Size = new System.Drawing.Size(45, 15);
             this.label1.TabIndex = 5;
             this.label1.Text = "Model:";
             // 
@@ -822,7 +825,7 @@ namespace CodeWalker
             this.label3.AutoSize = true;
             this.label3.Location = new System.Drawing.Point(3, 8);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(37, 13);
+            this.label3.Size = new System.Drawing.Size(42, 15);
             this.label3.TabIndex = 11;
             this.label3.Text = "Mode:";
             // 
@@ -869,7 +872,7 @@ namespace CodeWalker
             this.label27.AutoSize = true;
             this.label27.Location = new System.Drawing.Point(-2, 50);
             this.label27.Name = "label27";
-            this.label27.Size = new System.Drawing.Size(121, 13);
+            this.label27.Size = new System.Drawing.Size(141, 15);
             this.label27.TabIndex = 22;
             this.label27.Text = "Current camera position:";
             // 
@@ -942,9 +945,9 @@ namespace CodeWalker
             // 
             this.ShowLocatorCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.ShowLocatorCheckBox.AutoSize = true;
-            this.ShowLocatorCheckBox.Location = new System.Drawing.Point(101, 8);
+            this.ShowLocatorCheckBox.Location = new System.Drawing.Point(90, 8);
             this.ShowLocatorCheckBox.Name = "ShowLocatorCheckBox";
-            this.ShowLocatorCheckBox.Size = new System.Drawing.Size(88, 17);
+            this.ShowLocatorCheckBox.Size = new System.Drawing.Size(99, 19);
             this.ShowLocatorCheckBox.TabIndex = 13;
             this.ShowLocatorCheckBox.Text = "Show marker";
             this.ShowLocatorCheckBox.UseVisualStyleBackColor = true;
@@ -955,7 +958,7 @@ namespace CodeWalker
             this.label6.AutoSize = true;
             this.label6.Location = new System.Drawing.Point(-2, 8);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(79, 13);
+            this.label6.Size = new System.Drawing.Size(84, 15);
             this.label6.TabIndex = 13;
             this.label6.Text = "Locate: X, Y, Z";
             // 
@@ -975,7 +978,7 @@ namespace CodeWalker
             this.label7.AutoSize = true;
             this.label7.Location = new System.Drawing.Point(-2, 101);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(122, 13);
+            this.label7.Size = new System.Drawing.Size(138, 15);
             this.label7.TabIndex = 11;
             this.label7.Text = "Multi-find: X, Y, Z, Name";
             // 
@@ -1022,7 +1025,7 @@ namespace CodeWalker
             this.label25.AutoSize = true;
             this.label25.Location = new System.Drawing.Point(6, 33);
             this.label25.Name = "label25";
-            this.label25.Size = new System.Drawing.Size(37, 13);
+            this.label25.Size = new System.Drawing.Size(42, 15);
             this.label25.TabIndex = 28;
             this.label25.Text = "Mode:";
             // 
@@ -1257,7 +1260,7 @@ namespace CodeWalker
             this.MouseSelectCheckBox.AutoSize = true;
             this.MouseSelectCheckBox.Location = new System.Drawing.Point(8, 7);
             this.MouseSelectCheckBox.Name = "MouseSelectCheckBox";
-            this.MouseSelectCheckBox.Size = new System.Drawing.Size(143, 17);
+            this.MouseSelectCheckBox.Size = new System.Drawing.Size(161, 19);
             this.MouseSelectCheckBox.TabIndex = 22;
             this.MouseSelectCheckBox.Text = "Mouse select (right click)";
             this.MouseSelectCheckBox.UseVisualStyleBackColor = true;
@@ -1295,6 +1298,8 @@ namespace CodeWalker
             // 
             // tabPage8
             // 
+            this.tabPage8.Controls.Add(this.label31);
+            this.tabPage8.Controls.Add(this.ThemeComboBox);
             this.tabPage8.Controls.Add(this.AdvancedSettingsButton);
             this.tabPage8.Controls.Add(this.ControlSettingsButton);
             this.tabPage8.Controls.Add(this.MapViewDetailLabel);
@@ -1352,7 +1357,7 @@ namespace CodeWalker
             this.MapViewDetailLabel.AutoSize = true;
             this.MapViewDetailLabel.Location = new System.Drawing.Point(94, 391);
             this.MapViewDetailLabel.Name = "MapViewDetailLabel";
-            this.MapViewDetailLabel.Size = new System.Drawing.Size(22, 13);
+            this.MapViewDetailLabel.Size = new System.Drawing.Size(24, 15);
             this.MapViewDetailLabel.TabIndex = 66;
             this.MapViewDetailLabel.Text = "1.0";
             // 
@@ -1361,7 +1366,7 @@ namespace CodeWalker
             this.label28.AutoSize = true;
             this.label28.Location = new System.Drawing.Point(4, 391);
             this.label28.Name = "label28";
-            this.label28.Size = new System.Drawing.Size(84, 13);
+            this.label28.Size = new System.Drawing.Size(95, 15);
             this.label28.TabIndex = 65;
             this.label28.Text = "Map view detail:";
             // 
@@ -1402,7 +1407,7 @@ namespace CodeWalker
             this.label24.AutoSize = true;
             this.label24.Location = new System.Drawing.Point(4, 308);
             this.label24.Name = "label24";
-            this.label24.Size = new System.Drawing.Size(75, 13);
+            this.label24.Size = new System.Drawing.Size(89, 15);
             this.label24.TabIndex = 63;
             this.label24.Text = "Camera mode:";
             // 
@@ -1413,7 +1418,7 @@ namespace CodeWalker
             this.WaterQuadsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.WaterQuadsCheckBox.Location = new System.Drawing.Point(10, 104);
             this.WaterQuadsCheckBox.Name = "WaterQuadsCheckBox";
-            this.WaterQuadsCheckBox.Size = new System.Drawing.Size(114, 17);
+            this.WaterQuadsCheckBox.Size = new System.Drawing.Size(127, 19);
             this.WaterQuadsCheckBox.TabIndex = 39;
             this.WaterQuadsCheckBox.Text = "Show water quads";
             this.WaterQuadsCheckBox.UseVisualStyleBackColor = true;
@@ -1424,7 +1429,7 @@ namespace CodeWalker
             this.FieldOfViewLabel.AutoSize = true;
             this.FieldOfViewLabel.Location = new System.Drawing.Point(79, 335);
             this.FieldOfViewLabel.Name = "FieldOfViewLabel";
-            this.FieldOfViewLabel.Size = new System.Drawing.Size(22, 13);
+            this.FieldOfViewLabel.Size = new System.Drawing.Size(24, 15);
             this.FieldOfViewLabel.TabIndex = 59;
             this.FieldOfViewLabel.Text = "1.0";
             // 
@@ -1433,7 +1438,7 @@ namespace CodeWalker
             this.label22.AutoSize = true;
             this.label22.Location = new System.Drawing.Point(4, 335);
             this.label22.Name = "label22";
-            this.label22.Size = new System.Drawing.Size(69, 13);
+            this.label22.Size = new System.Drawing.Size(77, 15);
             this.label22.TabIndex = 58;
             this.label22.Text = "Field of view:";
             // 
@@ -1442,7 +1447,7 @@ namespace CodeWalker
             this.TimedEntitiesAlwaysOnCheckBox.AutoSize = true;
             this.TimedEntitiesAlwaysOnCheckBox.Location = new System.Drawing.Point(131, 58);
             this.TimedEntitiesAlwaysOnCheckBox.Name = "TimedEntitiesAlwaysOnCheckBox";
-            this.TimedEntitiesAlwaysOnCheckBox.Size = new System.Drawing.Size(58, 17);
+            this.TimedEntitiesAlwaysOnCheckBox.Size = new System.Drawing.Size(63, 19);
             this.TimedEntitiesAlwaysOnCheckBox.TabIndex = 37;
             this.TimedEntitiesAlwaysOnCheckBox.Text = "always";
             this.TimedEntitiesAlwaysOnCheckBox.UseVisualStyleBackColor = true;
@@ -1455,7 +1460,7 @@ namespace CodeWalker
             this.GrassCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.GrassCheckBox.Location = new System.Drawing.Point(10, 35);
             this.GrassCheckBox.Name = "GrassCheckBox";
-            this.GrassCheckBox.Size = new System.Drawing.Size(81, 17);
+            this.GrassCheckBox.Size = new System.Drawing.Size(90, 19);
             this.GrassCheckBox.TabIndex = 35;
             this.GrassCheckBox.Text = "Show grass";
             this.GrassCheckBox.UseVisualStyleBackColor = true;
@@ -1468,7 +1473,7 @@ namespace CodeWalker
             this.InteriorsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.InteriorsCheckBox.Location = new System.Drawing.Point(10, 81);
             this.InteriorsCheckBox.Name = "InteriorsCheckBox";
-            this.InteriorsCheckBox.Size = new System.Drawing.Size(92, 17);
+            this.InteriorsCheckBox.Size = new System.Drawing.Size(104, 19);
             this.InteriorsCheckBox.TabIndex = 38;
             this.InteriorsCheckBox.Text = "Show interiors";
             this.InteriorsCheckBox.UseVisualStyleBackColor = true;
@@ -1481,7 +1486,7 @@ namespace CodeWalker
             this.CollisionMeshLayerDrawableCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.CollisionMeshLayerDrawableCheckBox.Location = new System.Drawing.Point(118, 247);
             this.CollisionMeshLayerDrawableCheckBox.Name = "CollisionMeshLayerDrawableCheckBox";
-            this.CollisionMeshLayerDrawableCheckBox.Size = new System.Drawing.Size(71, 17);
+            this.CollisionMeshLayerDrawableCheckBox.Size = new System.Drawing.Size(79, 19);
             this.CollisionMeshLayerDrawableCheckBox.TabIndex = 52;
             this.CollisionMeshLayerDrawableCheckBox.Text = "Drawable";
             this.CollisionMeshLayerDrawableCheckBox.UseVisualStyleBackColor = true;
@@ -1494,7 +1499,7 @@ namespace CodeWalker
             this.CollisionMeshLayer2CheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.CollisionMeshLayer2CheckBox.Location = new System.Drawing.Point(82, 247);
             this.CollisionMeshLayer2CheckBox.Name = "CollisionMeshLayer2CheckBox";
-            this.CollisionMeshLayer2CheckBox.Size = new System.Drawing.Size(32, 17);
+            this.CollisionMeshLayer2CheckBox.Size = new System.Drawing.Size(33, 19);
             this.CollisionMeshLayer2CheckBox.TabIndex = 51;
             this.CollisionMeshLayer2CheckBox.Text = "2";
             this.CollisionMeshLayer2CheckBox.UseVisualStyleBackColor = true;
@@ -1507,7 +1512,7 @@ namespace CodeWalker
             this.CollisionMeshLayer1CheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.CollisionMeshLayer1CheckBox.Location = new System.Drawing.Point(46, 247);
             this.CollisionMeshLayer1CheckBox.Name = "CollisionMeshLayer1CheckBox";
-            this.CollisionMeshLayer1CheckBox.Size = new System.Drawing.Size(32, 17);
+            this.CollisionMeshLayer1CheckBox.Size = new System.Drawing.Size(33, 19);
             this.CollisionMeshLayer1CheckBox.TabIndex = 50;
             this.CollisionMeshLayer1CheckBox.Text = "1";
             this.CollisionMeshLayer1CheckBox.UseVisualStyleBackColor = true;
@@ -1518,7 +1523,7 @@ namespace CodeWalker
             this.label13.AutoSize = true;
             this.label13.Location = new System.Drawing.Point(4, 229);
             this.label13.Name = "label13";
-            this.label13.Size = new System.Drawing.Size(106, 13);
+            this.label13.Size = new System.Drawing.Size(126, 15);
             this.label13.TabIndex = 54;
             this.label13.Text = "Collision mesh layers:";
             // 
@@ -1529,7 +1534,7 @@ namespace CodeWalker
             this.CollisionMeshLayer0CheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.CollisionMeshLayer0CheckBox.Location = new System.Drawing.Point(10, 247);
             this.CollisionMeshLayer0CheckBox.Name = "CollisionMeshLayer0CheckBox";
-            this.CollisionMeshLayer0CheckBox.Size = new System.Drawing.Size(32, 17);
+            this.CollisionMeshLayer0CheckBox.Size = new System.Drawing.Size(33, 19);
             this.CollisionMeshLayer0CheckBox.TabIndex = 49;
             this.CollisionMeshLayer0CheckBox.Text = "0";
             this.CollisionMeshLayer0CheckBox.UseVisualStyleBackColor = true;
@@ -1540,7 +1545,7 @@ namespace CodeWalker
             this.label12.AutoSize = true;
             this.label12.Location = new System.Drawing.Point(4, 178);
             this.label12.Name = "label12";
-            this.label12.Size = new System.Drawing.Size(129, 13);
+            this.label12.Size = new System.Drawing.Size(148, 15);
             this.label12.TabIndex = 51;
             this.label12.Text = "Collision/nav mesh range:";
             // 
@@ -1564,7 +1569,7 @@ namespace CodeWalker
             this.CollisionMeshesCheckBox.AutoSize = true;
             this.CollisionMeshesCheckBox.Location = new System.Drawing.Point(10, 156);
             this.CollisionMeshesCheckBox.Name = "CollisionMeshesCheckBox";
-            this.CollisionMeshesCheckBox.Size = new System.Drawing.Size(132, 17);
+            this.CollisionMeshesCheckBox.Size = new System.Drawing.Size(152, 19);
             this.CollisionMeshesCheckBox.TabIndex = 47;
             this.CollisionMeshesCheckBox.Text = "Show collision meshes";
             this.CollisionMeshesCheckBox.UseVisualStyleBackColor = true;
@@ -1575,7 +1580,7 @@ namespace CodeWalker
             this.FullScreenCheckBox.AutoSize = true;
             this.FullScreenCheckBox.Location = new System.Drawing.Point(10, 9);
             this.FullScreenCheckBox.Name = "FullScreenCheckBox";
-            this.FullScreenCheckBox.Size = new System.Drawing.Size(173, 17);
+            this.FullScreenCheckBox.Size = new System.Drawing.Size(200, 19);
             this.FullScreenCheckBox.TabIndex = 28;
             this.FullScreenCheckBox.Text = "Full screen (borderless window)";
             this.FullScreenCheckBox.UseVisualStyleBackColor = true;
@@ -1588,7 +1593,7 @@ namespace CodeWalker
             this.TimedEntitiesCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.TimedEntitiesCheckBox.Location = new System.Drawing.Point(10, 58);
             this.TimedEntitiesCheckBox.Name = "TimedEntitiesCheckBox";
-            this.TimedEntitiesCheckBox.Size = new System.Drawing.Size(117, 17);
+            this.TimedEntitiesCheckBox.Size = new System.Drawing.Size(133, 19);
             this.TimedEntitiesCheckBox.TabIndex = 36;
             this.TimedEntitiesCheckBox.Text = "Show timed entities";
             this.TimedEntitiesCheckBox.UseVisualStyleBackColor = true;
@@ -1634,7 +1639,7 @@ namespace CodeWalker
             this.WireframeCheckBox.AutoSize = true;
             this.WireframeCheckBox.Location = new System.Drawing.Point(10, 115);
             this.WireframeCheckBox.Name = "WireframeCheckBox";
-            this.WireframeCheckBox.Size = new System.Drawing.Size(74, 17);
+            this.WireframeCheckBox.Size = new System.Drawing.Size(83, 19);
             this.WireframeCheckBox.TabIndex = 49;
             this.WireframeCheckBox.Text = "Wireframe";
             this.WireframeCheckBox.UseVisualStyleBackColor = true;
@@ -1666,7 +1671,7 @@ namespace CodeWalker
             this.label11.AutoSize = true;
             this.label11.Location = new System.Drawing.Point(4, 46);
             this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(67, 13);
+            this.label11.Size = new System.Drawing.Size(78, 15);
             this.label11.TabIndex = 50;
             this.label11.Text = "Tex sampler:";
             // 
@@ -1703,7 +1708,7 @@ namespace CodeWalker
             this.label10.AutoSize = true;
             this.label10.Location = new System.Drawing.Point(4, 19);
             this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(74, 13);
+            this.label10.Size = new System.Drawing.Size(86, 15);
             this.label10.TabIndex = 48;
             this.label10.Text = "Render mode:";
             // 
@@ -1714,7 +1719,7 @@ namespace CodeWalker
             this.AnisotropicFilteringCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.AnisotropicFilteringCheckBox.Location = new System.Drawing.Point(10, 138);
             this.AnisotropicFilteringCheckBox.Name = "AnisotropicFilteringCheckBox";
-            this.AnisotropicFilteringCheckBox.Size = new System.Drawing.Size(114, 17);
+            this.AnisotropicFilteringCheckBox.Size = new System.Drawing.Size(129, 19);
             this.AnisotropicFilteringCheckBox.TabIndex = 50;
             this.AnisotropicFilteringCheckBox.Text = "Anisotropic filtering";
             this.AnisotropicFilteringCheckBox.UseVisualStyleBackColor = true;
@@ -1725,7 +1730,7 @@ namespace CodeWalker
             this.ProxiesCheckBox.AutoSize = true;
             this.ProxiesCheckBox.Location = new System.Drawing.Point(10, 199);
             this.ProxiesCheckBox.Name = "ProxiesCheckBox";
-            this.ProxiesCheckBox.Size = new System.Drawing.Size(89, 17);
+            this.ProxiesCheckBox.Size = new System.Drawing.Size(100, 19);
             this.ProxiesCheckBox.TabIndex = 52;
             this.ProxiesCheckBox.Text = "Show proxies";
             this.ProxiesCheckBox.UseVisualStyleBackColor = true;
@@ -1738,7 +1743,7 @@ namespace CodeWalker
             this.WaitForChildrenCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.WaitForChildrenCheckBox.Location = new System.Drawing.Point(10, 161);
             this.WaitForChildrenCheckBox.Name = "WaitForChildrenCheckBox";
-            this.WaitForChildrenCheckBox.Size = new System.Drawing.Size(138, 17);
+            this.WaitForChildrenCheckBox.Size = new System.Drawing.Size(154, 19);
             this.WaitForChildrenCheckBox.TabIndex = 51;
             this.WaitForChildrenCheckBox.Text = "Wait for children to load";
             this.WaitForChildrenCheckBox.UseVisualStyleBackColor = true;
@@ -1749,7 +1754,7 @@ namespace CodeWalker
             this.label14.AutoSize = true;
             this.label14.Location = new System.Drawing.Point(4, 73);
             this.label14.Name = "label14";
-            this.label14.Size = new System.Drawing.Size(63, 13);
+            this.label14.Size = new System.Drawing.Size(70, 15);
             this.label14.TabIndex = 56;
             this.label14.Text = "Tex coords:";
             // 
@@ -1815,7 +1820,7 @@ namespace CodeWalker
             this.label26.AutoSize = true;
             this.label26.Location = new System.Drawing.Point(4, 293);
             this.label26.Name = "label26";
-            this.label26.Size = new System.Drawing.Size(76, 13);
+            this.label26.Size = new System.Drawing.Size(88, 15);
             this.label26.TabIndex = 48;
             this.label26.Text = "Snap grid size:";
             // 
@@ -1824,7 +1829,7 @@ namespace CodeWalker
             this.SkeletonsCheckBox.AutoSize = true;
             this.SkeletonsCheckBox.Location = new System.Drawing.Point(10, 411);
             this.SkeletonsCheckBox.Name = "SkeletonsCheckBox";
-            this.SkeletonsCheckBox.Size = new System.Drawing.Size(101, 17);
+            this.SkeletonsCheckBox.Size = new System.Drawing.Size(112, 19);
             this.SkeletonsCheckBox.TabIndex = 55;
             this.SkeletonsCheckBox.Text = "Show skeletons";
             this.SkeletonsCheckBox.UseVisualStyleBackColor = true;
@@ -1837,7 +1842,7 @@ namespace CodeWalker
             this.AudioOuterBoundsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.AudioOuterBoundsCheckBox.Location = new System.Drawing.Point(10, 457);
             this.AudioOuterBoundsCheckBox.Name = "AudioOuterBoundsCheckBox";
-            this.AudioOuterBoundsCheckBox.Size = new System.Drawing.Size(147, 17);
+            this.AudioOuterBoundsCheckBox.Size = new System.Drawing.Size(166, 19);
             this.AudioOuterBoundsCheckBox.TabIndex = 57;
             this.AudioOuterBoundsCheckBox.Text = "Show audio outer bounds";
             this.AudioOuterBoundsCheckBox.UseVisualStyleBackColor = true;
@@ -1848,7 +1853,7 @@ namespace CodeWalker
             this.PopZonesCheckBox.AutoSize = true;
             this.PopZonesCheckBox.Location = new System.Drawing.Point(10, 388);
             this.PopZonesCheckBox.Name = "PopZonesCheckBox";
-            this.PopZonesCheckBox.Size = new System.Drawing.Size(136, 17);
+            this.PopZonesCheckBox.Size = new System.Drawing.Size(154, 19);
             this.PopZonesCheckBox.TabIndex = 54;
             this.PopZonesCheckBox.Text = "Show population zones";
             this.PopZonesCheckBox.UseVisualStyleBackColor = true;
@@ -1859,7 +1864,7 @@ namespace CodeWalker
             this.NavMeshesCheckBox.AutoSize = true;
             this.NavMeshesCheckBox.Location = new System.Drawing.Point(10, 365);
             this.NavMeshesCheckBox.Name = "NavMeshesCheckBox";
-            this.NavMeshesCheckBox.Size = new System.Drawing.Size(113, 17);
+            this.NavMeshesCheckBox.Size = new System.Drawing.Size(126, 19);
             this.NavMeshesCheckBox.TabIndex = 53;
             this.NavMeshesCheckBox.Text = "Show nav meshes";
             this.NavMeshesCheckBox.UseVisualStyleBackColor = true;
@@ -1870,7 +1875,7 @@ namespace CodeWalker
             this.TrainPathsCheckBox.AutoSize = true;
             this.TrainPathsCheckBox.Location = new System.Drawing.Point(10, 342);
             this.TrainPathsCheckBox.Name = "TrainPathsCheckBox";
-            this.TrainPathsCheckBox.Size = new System.Drawing.Size(105, 17);
+            this.TrainPathsCheckBox.Size = new System.Drawing.Size(117, 19);
             this.TrainPathsCheckBox.TabIndex = 52;
             this.TrainPathsCheckBox.Text = "Show train paths";
             this.TrainPathsCheckBox.UseVisualStyleBackColor = true;
@@ -1883,7 +1888,7 @@ namespace CodeWalker
             this.PathsDepthClipCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.PathsDepthClipCheckBox.Location = new System.Drawing.Point(10, 434);
             this.PathsDepthClipCheckBox.Name = "PathsDepthClipCheckBox";
-            this.PathsDepthClipCheckBox.Size = new System.Drawing.Size(102, 17);
+            this.PathsDepthClipCheckBox.Size = new System.Drawing.Size(113, 19);
             this.PathsDepthClipCheckBox.TabIndex = 56;
             this.PathsDepthClipCheckBox.Text = "Paths depth clip";
             this.PathsDepthClipCheckBox.UseVisualStyleBackColor = true;
@@ -1896,7 +1901,7 @@ namespace CodeWalker
             this.PathBoundsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.PathBoundsCheckBox.Location = new System.Drawing.Point(98, 319);
             this.PathBoundsCheckBox.Name = "PathBoundsCheckBox";
-            this.PathBoundsCheckBox.Size = new System.Drawing.Size(86, 17);
+            this.PathBoundsCheckBox.Size = new System.Drawing.Size(95, 19);
             this.PathBoundsCheckBox.TabIndex = 51;
             this.PathBoundsCheckBox.Text = "Path bounds";
             this.PathBoundsCheckBox.UseVisualStyleBackColor = true;
@@ -1909,7 +1914,7 @@ namespace CodeWalker
             this.SelectionWidgetCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.SelectionWidgetCheckBox.Location = new System.Drawing.Point(10, 241);
             this.SelectionWidgetCheckBox.Name = "SelectionWidgetCheckBox";
-            this.SelectionWidgetCheckBox.Size = new System.Drawing.Size(87, 17);
+            this.SelectionWidgetCheckBox.Size = new System.Drawing.Size(96, 19);
             this.SelectionWidgetCheckBox.TabIndex = 46;
             this.SelectionWidgetCheckBox.Text = "Show widget";
             this.SelectionWidgetCheckBox.UseVisualStyleBackColor = true;
@@ -1930,9 +1935,9 @@ namespace CodeWalker
             // 
             this.ShowToolbarCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.ShowToolbarCheckBox.AutoSize = true;
-            this.ShowToolbarCheckBox.Location = new System.Drawing.Point(10, 264);
+            this.ShowToolbarCheckBox.Location = new System.Drawing.Point(10, 262);
             this.ShowToolbarCheckBox.Name = "ShowToolbarCheckBox";
-            this.ShowToolbarCheckBox.Size = new System.Drawing.Size(108, 17);
+            this.ShowToolbarCheckBox.Size = new System.Drawing.Size(120, 19);
             this.ShowToolbarCheckBox.TabIndex = 47;
             this.ShowToolbarCheckBox.Text = "Show Toolbar (T)";
             this.ShowToolbarCheckBox.UseVisualStyleBackColor = true;
@@ -1943,7 +1948,7 @@ namespace CodeWalker
             this.label4.AutoSize = true;
             this.label4.Location = new System.Drawing.Point(4, 9);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(67, 13);
+            this.label4.Size = new System.Drawing.Size(76, 15);
             this.label4.TabIndex = 17;
             this.label4.Text = "Marker style:";
             // 
@@ -1963,7 +1968,7 @@ namespace CodeWalker
             this.label5.AutoSize = true;
             this.label5.Location = new System.Drawing.Point(4, 36);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(70, 13);
+            this.label5.Size = new System.Drawing.Size(78, 15);
             this.label5.TabIndex = 19;
             this.label5.Text = "Locator style:";
             // 
@@ -1972,7 +1977,7 @@ namespace CodeWalker
             this.MarkerDepthClipCheckBox.AutoSize = true;
             this.MarkerDepthClipCheckBox.Location = new System.Drawing.Point(10, 60);
             this.MarkerDepthClipCheckBox.Name = "MarkerDepthClipCheckBox";
-            this.MarkerDepthClipCheckBox.Size = new System.Drawing.Size(108, 17);
+            this.MarkerDepthClipCheckBox.Size = new System.Drawing.Size(121, 19);
             this.MarkerDepthClipCheckBox.TabIndex = 40;
             this.MarkerDepthClipCheckBox.Text = "Marker depth clip";
             this.MarkerDepthClipCheckBox.UseVisualStyleBackColor = true;
@@ -1984,7 +1989,7 @@ namespace CodeWalker
             this.label9.AutoSize = true;
             this.label9.Location = new System.Drawing.Point(4, 151);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(76, 13);
+            this.label9.Size = new System.Drawing.Size(87, 15);
             this.label9.TabIndex = 27;
             this.label9.Text = "Bounds range:";
             // 
@@ -1993,7 +1998,7 @@ namespace CodeWalker
             this.PathsCheckBox.AutoSize = true;
             this.PathsCheckBox.Location = new System.Drawing.Point(10, 319);
             this.PathsCheckBox.Name = "PathsCheckBox";
-            this.PathsCheckBox.Size = new System.Drawing.Size(82, 17);
+            this.PathsCheckBox.Size = new System.Drawing.Size(90, 19);
             this.PathsCheckBox.TabIndex = 50;
             this.PathsCheckBox.Text = "Show paths";
             this.PathsCheckBox.UseVisualStyleBackColor = true;
@@ -2006,7 +2011,7 @@ namespace CodeWalker
             this.SelectionBoundsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.SelectionBoundsCheckBox.Location = new System.Drawing.Point(10, 218);
             this.SelectionBoundsCheckBox.Name = "SelectionBoundsCheckBox";
-            this.SelectionBoundsCheckBox.Size = new System.Drawing.Size(136, 17);
+            this.SelectionBoundsCheckBox.Size = new System.Drawing.Size(153, 19);
             this.SelectionBoundsCheckBox.TabIndex = 45;
             this.SelectionBoundsCheckBox.Text = "Show selection bounds";
             this.SelectionBoundsCheckBox.UseVisualStyleBackColor = true;
@@ -2019,7 +2024,7 @@ namespace CodeWalker
             this.BoundsDepthClipCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.BoundsDepthClipCheckBox.Location = new System.Drawing.Point(10, 129);
             this.BoundsDepthClipCheckBox.Name = "BoundsDepthClipCheckBox";
-            this.BoundsDepthClipCheckBox.Size = new System.Drawing.Size(111, 17);
+            this.BoundsDepthClipCheckBox.Size = new System.Drawing.Size(124, 19);
             this.BoundsDepthClipCheckBox.TabIndex = 42;
             this.BoundsDepthClipCheckBox.Text = "Bounds depth clip";
             this.BoundsDepthClipCheckBox.UseVisualStyleBackColor = true;
@@ -2059,7 +2064,7 @@ namespace CodeWalker
             this.label8.AutoSize = true;
             this.label8.Location = new System.Drawing.Point(4, 105);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(70, 13);
+            this.label8.Size = new System.Drawing.Size(79, 15);
             this.label8.TabIndex = 25;
             this.label8.Text = "Bounds style:";
             // 
@@ -2115,7 +2120,7 @@ namespace CodeWalker
             this.label29.AutoSize = true;
             this.label29.Location = new System.Drawing.Point(4, 358);
             this.label29.Name = "label29";
-            this.label29.Size = new System.Drawing.Size(44, 13);
+            this.label29.Size = new System.Drawing.Size(50, 15);
             this.label29.TabIndex = 64;
             this.label29.Text = "Region:";
             // 
@@ -2152,7 +2157,7 @@ namespace CodeWalker
             this.label23.AutoSize = true;
             this.label23.Location = new System.Drawing.Point(4, 412);
             this.label23.Name = "label23";
-            this.label23.Size = new System.Drawing.Size(69, 13);
+            this.label23.Size = new System.Drawing.Size(81, 15);
             this.label23.TabIndex = 61;
             this.label23.Text = "Cloud param:";
             // 
@@ -2174,7 +2179,7 @@ namespace CodeWalker
             this.label21.AutoSize = true;
             this.label21.Location = new System.Drawing.Point(4, 385);
             this.label21.Name = "label21";
-            this.label21.Size = new System.Drawing.Size(42, 13);
+            this.label21.Size = new System.Drawing.Size(48, 15);
             this.label21.TabIndex = 59;
             this.label21.Text = "Clouds:";
             // 
@@ -2183,7 +2188,7 @@ namespace CodeWalker
             this.TimeSpeedLabel.AutoSize = true;
             this.TimeSpeedLabel.Location = new System.Drawing.Point(78, 263);
             this.TimeSpeedLabel.Name = "TimeSpeedLabel";
-            this.TimeSpeedLabel.Size = new System.Drawing.Size(63, 13);
+            this.TimeSpeedLabel.Size = new System.Drawing.Size(70, 15);
             this.TimeSpeedLabel.TabIndex = 58;
             this.TimeSpeedLabel.Text = "0.5 min/sec";
             // 
@@ -2192,7 +2197,7 @@ namespace CodeWalker
             this.label20.AutoSize = true;
             this.label20.Location = new System.Drawing.Point(3, 263);
             this.label20.Name = "label20";
-            this.label20.Size = new System.Drawing.Size(65, 13);
+            this.label20.Size = new System.Drawing.Size(75, 15);
             this.label20.TabIndex = 57;
             this.label20.Text = "Time speed:";
             // 
@@ -2228,7 +2233,7 @@ namespace CodeWalker
             this.ArtificialAmbientLightCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.ArtificialAmbientLightCheckBox.Location = new System.Drawing.Point(10, 129);
             this.ArtificialAmbientLightCheckBox.Name = "ArtificialAmbientLightCheckBox";
-            this.ArtificialAmbientLightCheckBox.Size = new System.Drawing.Size(124, 17);
+            this.ArtificialAmbientLightCheckBox.Size = new System.Drawing.Size(142, 19);
             this.ArtificialAmbientLightCheckBox.TabIndex = 36;
             this.ArtificialAmbientLightCheckBox.Text = "Artificial ambient light";
             this.ArtificialAmbientLightCheckBox.UseVisualStyleBackColor = true;
@@ -2241,7 +2246,7 @@ namespace CodeWalker
             this.NaturalAmbientLightCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.NaturalAmbientLightCheckBox.Location = new System.Drawing.Point(10, 106);
             this.NaturalAmbientLightCheckBox.Name = "NaturalAmbientLightCheckBox";
-            this.NaturalAmbientLightCheckBox.Size = new System.Drawing.Size(122, 17);
+            this.NaturalAmbientLightCheckBox.Size = new System.Drawing.Size(140, 19);
             this.NaturalAmbientLightCheckBox.TabIndex = 35;
             this.NaturalAmbientLightCheckBox.Text = "Natural ambient light";
             this.NaturalAmbientLightCheckBox.UseVisualStyleBackColor = true;
@@ -2254,7 +2259,7 @@ namespace CodeWalker
             this.DistantLODLightsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.DistantLODLightsCheckBox.Location = new System.Drawing.Point(10, 83);
             this.DistantLODLightsCheckBox.Name = "DistantLODLightsCheckBox";
-            this.DistantLODLightsCheckBox.Size = new System.Drawing.Size(111, 17);
+            this.DistantLODLightsCheckBox.Size = new System.Drawing.Size(124, 19);
             this.DistantLODLightsCheckBox.TabIndex = 34;
             this.DistantLODLightsCheckBox.Text = "Distant LOD lights";
             this.DistantLODLightsCheckBox.UseVisualStyleBackColor = true;
@@ -2267,7 +2272,7 @@ namespace CodeWalker
             this.HDRRenderingCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.HDRRenderingCheckBox.Location = new System.Drawing.Point(10, 9);
             this.HDRRenderingCheckBox.Name = "HDRRenderingCheckBox";
-            this.HDRRenderingCheckBox.Size = new System.Drawing.Size(97, 17);
+            this.HDRRenderingCheckBox.Size = new System.Drawing.Size(109, 19);
             this.HDRRenderingCheckBox.TabIndex = 31;
             this.HDRRenderingCheckBox.Text = "HDR rendering";
             this.HDRRenderingCheckBox.UseVisualStyleBackColor = true;
@@ -2280,7 +2285,7 @@ namespace CodeWalker
             this.ControlTimeOfDayCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.ControlTimeOfDayCheckBox.Location = new System.Drawing.Point(10, 180);
             this.ControlTimeOfDayCheckBox.Name = "ControlTimeOfDayCheckBox";
-            this.ControlTimeOfDayCheckBox.Size = new System.Drawing.Size(166, 17);
+            this.ControlTimeOfDayCheckBox.Size = new System.Drawing.Size(191, 19);
             this.ControlTimeOfDayCheckBox.TabIndex = 38;
             this.ControlTimeOfDayCheckBox.Text = "Control time of day (right-drag)";
             this.ControlTimeOfDayCheckBox.UseVisualStyleBackColor = true;
@@ -2291,7 +2296,7 @@ namespace CodeWalker
             this.TimeOfDayLabel.AutoSize = true;
             this.TimeOfDayLabel.Location = new System.Drawing.Point(75, 208);
             this.TimeOfDayLabel.Name = "TimeOfDayLabel";
-            this.TimeOfDayLabel.Size = new System.Drawing.Size(34, 13);
+            this.TimeOfDayLabel.Size = new System.Drawing.Size(38, 15);
             this.TimeOfDayLabel.TabIndex = 54;
             this.TimeOfDayLabel.Text = "12:00";
             // 
@@ -2300,7 +2305,7 @@ namespace CodeWalker
             this.label19.AutoSize = true;
             this.label19.Location = new System.Drawing.Point(4, 208);
             this.label19.Name = "label19";
-            this.label19.Size = new System.Drawing.Size(65, 13);
+            this.label19.Size = new System.Drawing.Size(73, 15);
             this.label19.TabIndex = 53;
             this.label19.Text = "Time of day:";
             // 
@@ -2337,7 +2342,7 @@ namespace CodeWalker
             this.label17.AutoSize = true;
             this.label17.Location = new System.Drawing.Point(4, 331);
             this.label17.Name = "label17";
-            this.label17.Size = new System.Drawing.Size(51, 13);
+            this.label17.Size = new System.Drawing.Size(56, 15);
             this.label17.TabIndex = 39;
             this.label17.Text = "Weather:";
             // 
@@ -2346,7 +2351,7 @@ namespace CodeWalker
             this.ControlLightDirectionCheckBox.AutoSize = true;
             this.ControlLightDirectionCheckBox.Location = new System.Drawing.Point(10, 157);
             this.ControlLightDirectionCheckBox.Name = "ControlLightDirectionCheckBox";
-            this.ControlLightDirectionCheckBox.Size = new System.Drawing.Size(177, 17);
+            this.ControlLightDirectionCheckBox.Size = new System.Drawing.Size(205, 19);
             this.ControlLightDirectionCheckBox.TabIndex = 37;
             this.ControlLightDirectionCheckBox.Text = "Control light direction (right-drag)";
             this.ControlLightDirectionCheckBox.UseVisualStyleBackColor = true;
@@ -2359,7 +2364,7 @@ namespace CodeWalker
             this.SkydomeCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.SkydomeCheckBox.Location = new System.Drawing.Point(10, 55);
             this.SkydomeCheckBox.Name = "SkydomeCheckBox";
-            this.SkydomeCheckBox.Size = new System.Drawing.Size(70, 17);
+            this.SkydomeCheckBox.Size = new System.Drawing.Size(77, 19);
             this.SkydomeCheckBox.TabIndex = 33;
             this.SkydomeCheckBox.Text = "Skydome";
             this.SkydomeCheckBox.UseVisualStyleBackColor = true;
@@ -2370,7 +2375,7 @@ namespace CodeWalker
             this.ShadowsCheckBox.AutoSize = true;
             this.ShadowsCheckBox.Location = new System.Drawing.Point(10, 32);
             this.ShadowsCheckBox.Name = "ShadowsCheckBox";
-            this.ShadowsCheckBox.Size = new System.Drawing.Size(70, 17);
+            this.ShadowsCheckBox.Size = new System.Drawing.Size(77, 19);
             this.ShadowsCheckBox.TabIndex = 32;
             this.ShadowsCheckBox.Text = "Shadows";
             this.ShadowsCheckBox.UseVisualStyleBackColor = true;
@@ -2383,7 +2388,7 @@ namespace CodeWalker
             this.StatusBarCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.StatusBarCheckBox.Location = new System.Drawing.Point(119, 517);
             this.StatusBarCheckBox.Name = "StatusBarCheckBox";
-            this.StatusBarCheckBox.Size = new System.Drawing.Size(74, 17);
+            this.StatusBarCheckBox.Size = new System.Drawing.Size(81, 19);
             this.StatusBarCheckBox.TabIndex = 145;
             this.StatusBarCheckBox.Text = "Status bar";
             this.StatusBarCheckBox.UseVisualStyleBackColor = true;
@@ -2436,7 +2441,7 @@ namespace CodeWalker
             this.ErrorConsoleCheckBox.AutoSize = true;
             this.ErrorConsoleCheckBox.Location = new System.Drawing.Point(14, 517);
             this.ErrorConsoleCheckBox.Name = "ErrorConsoleCheckBox";
-            this.ErrorConsoleCheckBox.Size = new System.Drawing.Size(88, 17);
+            this.ErrorConsoleCheckBox.Size = new System.Drawing.Size(99, 19);
             this.ErrorConsoleCheckBox.TabIndex = 144;
             this.ErrorConsoleCheckBox.Text = "Error console";
             this.ErrorConsoleCheckBox.UseVisualStyleBackColor = true;
@@ -2547,12 +2552,12 @@ namespace CodeWalker
             this.ToolsMenuExtractShaders,
             this.ToolsMenuOptions});
             this.ToolsMenu.Name = "ToolsMenu";
-            this.ToolsMenu.Size = new System.Drawing.Size(166, 290);
+            this.ToolsMenu.Size = new System.Drawing.Size(177, 290);
             // 
             // ToolsMenuRPFBrowser
             // 
             this.ToolsMenuRPFBrowser.Name = "ToolsMenuRPFBrowser";
-            this.ToolsMenuRPFBrowser.Size = new System.Drawing.Size(165, 22);
+            this.ToolsMenuRPFBrowser.Size = new System.Drawing.Size(176, 22);
             this.ToolsMenuRPFBrowser.Text = "RPF Browser...";
             this.ToolsMenuRPFBrowser.Visible = false;
             this.ToolsMenuRPFBrowser.Click += new System.EventHandler(this.ToolsMenuRPFBrowser_Click);
@@ -2560,14 +2565,14 @@ namespace CodeWalker
             // ToolsMenuRPFExplorer
             // 
             this.ToolsMenuRPFExplorer.Name = "ToolsMenuRPFExplorer";
-            this.ToolsMenuRPFExplorer.Size = new System.Drawing.Size(165, 22);
+            this.ToolsMenuRPFExplorer.Size = new System.Drawing.Size(176, 22);
             this.ToolsMenuRPFExplorer.Text = "RPF Explorer...";
             this.ToolsMenuRPFExplorer.Click += new System.EventHandler(this.ToolsMenuRPFExplorer_Click);
             // 
             // ToolsMenuSelectionInfo
             // 
             this.ToolsMenuSelectionInfo.Name = "ToolsMenuSelectionInfo";
-            this.ToolsMenuSelectionInfo.Size = new System.Drawing.Size(165, 22);
+            this.ToolsMenuSelectionInfo.Size = new System.Drawing.Size(176, 22);
             this.ToolsMenuSelectionInfo.Text = "Selection info...";
             this.ToolsMenuSelectionInfo.Click += new System.EventHandler(this.ToolsMenuSelectionInfo_Click);
             // 
@@ -2575,14 +2580,14 @@ namespace CodeWalker
             // 
             this.ToolsMenuProjectWindow.Enabled = false;
             this.ToolsMenuProjectWindow.Name = "ToolsMenuProjectWindow";
-            this.ToolsMenuProjectWindow.Size = new System.Drawing.Size(165, 22);
+            this.ToolsMenuProjectWindow.Size = new System.Drawing.Size(176, 22);
             this.ToolsMenuProjectWindow.Text = "Project window...";
             this.ToolsMenuProjectWindow.Click += new System.EventHandler(this.ToolsMenuProjectWindow_Click);
             // 
             // ToolsMenuWorldSearch
             // 
             this.ToolsMenuWorldSearch.Name = "ToolsMenuWorldSearch";
-            this.ToolsMenuWorldSearch.Size = new System.Drawing.Size(165, 22);
+            this.ToolsMenuWorldSearch.Size = new System.Drawing.Size(176, 22);
             this.ToolsMenuWorldSearch.Text = "World search...";
             this.ToolsMenuWorldSearch.Click += new System.EventHandler(this.ToolsMenuWorldSearch_Click);
             // 
@@ -2590,14 +2595,14 @@ namespace CodeWalker
             // 
             this.ToolsMenuBinarySearch.Enabled = false;
             this.ToolsMenuBinarySearch.Name = "ToolsMenuBinarySearch";
-            this.ToolsMenuBinarySearch.Size = new System.Drawing.Size(165, 22);
+            this.ToolsMenuBinarySearch.Size = new System.Drawing.Size(176, 22);
             this.ToolsMenuBinarySearch.Text = "Binary search...";
             this.ToolsMenuBinarySearch.Click += new System.EventHandler(this.ToolsMenuBinarySearch_Click);
             // 
             // ToolsMenuJenkGen
             // 
             this.ToolsMenuJenkGen.Name = "ToolsMenuJenkGen";
-            this.ToolsMenuJenkGen.Size = new System.Drawing.Size(165, 22);
+            this.ToolsMenuJenkGen.Size = new System.Drawing.Size(176, 22);
             this.ToolsMenuJenkGen.Text = "JenkGen...";
             this.ToolsMenuJenkGen.Click += new System.EventHandler(this.ToolsMenuJenkGen_Click);
             // 
@@ -2605,42 +2610,42 @@ namespace CodeWalker
             // 
             this.ToolsMenuJenkInd.Enabled = false;
             this.ToolsMenuJenkInd.Name = "ToolsMenuJenkInd";
-            this.ToolsMenuJenkInd.Size = new System.Drawing.Size(165, 22);
+            this.ToolsMenuJenkInd.Size = new System.Drawing.Size(176, 22);
             this.ToolsMenuJenkInd.Text = "JenkInd...";
             this.ToolsMenuJenkInd.Click += new System.EventHandler(this.ToolsMenuJenkInd_Click);
             // 
             // ToolsMenuExtractScripts
             // 
             this.ToolsMenuExtractScripts.Name = "ToolsMenuExtractScripts";
-            this.ToolsMenuExtractScripts.Size = new System.Drawing.Size(165, 22);
+            this.ToolsMenuExtractScripts.Size = new System.Drawing.Size(176, 22);
             this.ToolsMenuExtractScripts.Text = "Extract scripts...";
             this.ToolsMenuExtractScripts.Click += new System.EventHandler(this.ToolsMenuExtractScripts_Click);
             // 
             // ToolsMenuExtractTextures
             // 
             this.ToolsMenuExtractTextures.Name = "ToolsMenuExtractTextures";
-            this.ToolsMenuExtractTextures.Size = new System.Drawing.Size(165, 22);
+            this.ToolsMenuExtractTextures.Size = new System.Drawing.Size(176, 22);
             this.ToolsMenuExtractTextures.Text = "Extract textures...";
             this.ToolsMenuExtractTextures.Click += new System.EventHandler(this.ToolsMenuExtractTextures_Click);
             // 
             // ToolsMenuExtractRawFiles
             // 
             this.ToolsMenuExtractRawFiles.Name = "ToolsMenuExtractRawFiles";
-            this.ToolsMenuExtractRawFiles.Size = new System.Drawing.Size(165, 22);
+            this.ToolsMenuExtractRawFiles.Size = new System.Drawing.Size(176, 22);
             this.ToolsMenuExtractRawFiles.Text = "Extract raw files...";
             this.ToolsMenuExtractRawFiles.Click += new System.EventHandler(this.ToolsMenuExtractRawFiles_Click);
             // 
             // ToolsMenuExtractShaders
             // 
             this.ToolsMenuExtractShaders.Name = "ToolsMenuExtractShaders";
-            this.ToolsMenuExtractShaders.Size = new System.Drawing.Size(165, 22);
+            this.ToolsMenuExtractShaders.Size = new System.Drawing.Size(176, 22);
             this.ToolsMenuExtractShaders.Text = "Extract shaders...";
             this.ToolsMenuExtractShaders.Click += new System.EventHandler(this.ToolsMenuExtractShaders_Click);
             // 
             // ToolsMenuOptions
             // 
             this.ToolsMenuOptions.Name = "ToolsMenuOptions";
-            this.ToolsMenuOptions.Size = new System.Drawing.Size(165, 22);
+            this.ToolsMenuOptions.Size = new System.Drawing.Size(176, 22);
             this.ToolsMenuOptions.Text = "Options...";
             this.ToolsMenuOptions.Click += new System.EventHandler(this.ToolsMenuOptions_Click);
             // 
@@ -2702,35 +2707,35 @@ namespace CodeWalker
             // ToolbarNewProjectButton
             // 
             this.ToolbarNewProjectButton.Name = "ToolbarNewProjectButton";
-            this.ToolbarNewProjectButton.Size = new System.Drawing.Size(164, 22);
+            this.ToolbarNewProjectButton.Size = new System.Drawing.Size(176, 22);
             this.ToolbarNewProjectButton.Text = "New project";
             this.ToolbarNewProjectButton.Click += new System.EventHandler(this.ToolbarNewProjectButton_Click);
             // 
             // ToolbarNewYmapButton
             // 
             this.ToolbarNewYmapButton.Name = "ToolbarNewYmapButton";
-            this.ToolbarNewYmapButton.Size = new System.Drawing.Size(164, 22);
+            this.ToolbarNewYmapButton.Size = new System.Drawing.Size(176, 22);
             this.ToolbarNewYmapButton.Text = "New ymap file";
             this.ToolbarNewYmapButton.Click += new System.EventHandler(this.ToolbarNewYmapButton_Click);
             // 
             // ToolbarNewYndButton
             // 
             this.ToolbarNewYndButton.Name = "ToolbarNewYndButton";
-            this.ToolbarNewYndButton.Size = new System.Drawing.Size(164, 22);
+            this.ToolbarNewYndButton.Size = new System.Drawing.Size(176, 22);
             this.ToolbarNewYndButton.Text = "New ynd file";
             this.ToolbarNewYndButton.Click += new System.EventHandler(this.ToolbarNewYndButton_Click);
             // 
             // ToolbarNewTrainsButton
             // 
             this.ToolbarNewTrainsButton.Name = "ToolbarNewTrainsButton";
-            this.ToolbarNewTrainsButton.Size = new System.Drawing.Size(164, 22);
+            this.ToolbarNewTrainsButton.Size = new System.Drawing.Size(176, 22);
             this.ToolbarNewTrainsButton.Text = "New trains file";
             this.ToolbarNewTrainsButton.Click += new System.EventHandler(this.ToolbarNewTrainsButton_Click);
             // 
             // ToolbarNewScenarioButton
             // 
             this.ToolbarNewScenarioButton.Name = "ToolbarNewScenarioButton";
-            this.ToolbarNewScenarioButton.Size = new System.Drawing.Size(164, 22);
+            this.ToolbarNewScenarioButton.Size = new System.Drawing.Size(176, 22);
             this.ToolbarNewScenarioButton.Text = "New scenario file";
             this.ToolbarNewScenarioButton.Click += new System.EventHandler(this.ToolbarNewScenarioButton_Click);
             // 
@@ -2755,35 +2760,35 @@ namespace CodeWalker
             // ToolbarOpenProjectButton
             // 
             this.ToolbarOpenProjectButton.Name = "ToolbarOpenProjectButton";
-            this.ToolbarOpenProjectButton.Size = new System.Drawing.Size(178, 22);
+            this.ToolbarOpenProjectButton.Size = new System.Drawing.Size(191, 22);
             this.ToolbarOpenProjectButton.Text = "Open project...";
             this.ToolbarOpenProjectButton.Click += new System.EventHandler(this.ToolbarOpenProjectButton_Click);
             // 
             // ToolbarOpenYmapButton
             // 
             this.ToolbarOpenYmapButton.Name = "ToolbarOpenYmapButton";
-            this.ToolbarOpenYmapButton.Size = new System.Drawing.Size(178, 22);
+            this.ToolbarOpenYmapButton.Size = new System.Drawing.Size(191, 22);
             this.ToolbarOpenYmapButton.Text = "Open ymap file...";
             this.ToolbarOpenYmapButton.Click += new System.EventHandler(this.ToolbarOpenYmapButton_Click);
             // 
             // ToolbarOpenYndButton
             // 
             this.ToolbarOpenYndButton.Name = "ToolbarOpenYndButton";
-            this.ToolbarOpenYndButton.Size = new System.Drawing.Size(178, 22);
+            this.ToolbarOpenYndButton.Size = new System.Drawing.Size(191, 22);
             this.ToolbarOpenYndButton.Text = "Open ynd file...";
             this.ToolbarOpenYndButton.Click += new System.EventHandler(this.ToolbarOpenYndButton_Click);
             // 
             // ToolbarOpenTrainsButton
             // 
             this.ToolbarOpenTrainsButton.Name = "ToolbarOpenTrainsButton";
-            this.ToolbarOpenTrainsButton.Size = new System.Drawing.Size(178, 22);
+            this.ToolbarOpenTrainsButton.Size = new System.Drawing.Size(191, 22);
             this.ToolbarOpenTrainsButton.Text = "Open trains file...";
             this.ToolbarOpenTrainsButton.Click += new System.EventHandler(this.ToolbarOpenTrainsButton_Click);
             // 
             // ToolbarOpenScenarioButton
             // 
             this.ToolbarOpenScenarioButton.Name = "ToolbarOpenScenarioButton";
-            this.ToolbarOpenScenarioButton.Size = new System.Drawing.Size(178, 22);
+            this.ToolbarOpenScenarioButton.Size = new System.Drawing.Size(191, 22);
             this.ToolbarOpenScenarioButton.Text = "Open scenario file...";
             this.ToolbarOpenScenarioButton.Click += new System.EventHandler(this.ToolbarOpenScenarioButton_Click);
             // 
@@ -2848,105 +2853,105 @@ namespace CodeWalker
             this.ToolbarSelectEntityButton.Checked = true;
             this.ToolbarSelectEntityButton.CheckState = System.Windows.Forms.CheckState.Checked;
             this.ToolbarSelectEntityButton.Name = "ToolbarSelectEntityButton";
-            this.ToolbarSelectEntityButton.Size = new System.Drawing.Size(181, 22);
+            this.ToolbarSelectEntityButton.Size = new System.Drawing.Size(193, 22);
             this.ToolbarSelectEntityButton.Text = "Entity";
             this.ToolbarSelectEntityButton.Click += new System.EventHandler(this.ToolbarSelectEntityButton_Click);
             // 
             // ToolbarSelectEntityExtensionButton
             // 
             this.ToolbarSelectEntityExtensionButton.Name = "ToolbarSelectEntityExtensionButton";
-            this.ToolbarSelectEntityExtensionButton.Size = new System.Drawing.Size(181, 22);
+            this.ToolbarSelectEntityExtensionButton.Size = new System.Drawing.Size(193, 22);
             this.ToolbarSelectEntityExtensionButton.Text = "Entity Extension";
             this.ToolbarSelectEntityExtensionButton.Click += new System.EventHandler(this.ToolbarSelectEntityExtensionButton_Click);
             // 
             // ToolbarSelectArchetypeExtensionButton
             // 
             this.ToolbarSelectArchetypeExtensionButton.Name = "ToolbarSelectArchetypeExtensionButton";
-            this.ToolbarSelectArchetypeExtensionButton.Size = new System.Drawing.Size(181, 22);
+            this.ToolbarSelectArchetypeExtensionButton.Size = new System.Drawing.Size(193, 22);
             this.ToolbarSelectArchetypeExtensionButton.Text = "Archetype Extension";
             this.ToolbarSelectArchetypeExtensionButton.Click += new System.EventHandler(this.ToolbarSelectArchetypeExtensionButton_Click);
             // 
             // ToolbarSelectTimeCycleModifierButton
             // 
             this.ToolbarSelectTimeCycleModifierButton.Name = "ToolbarSelectTimeCycleModifierButton";
-            this.ToolbarSelectTimeCycleModifierButton.Size = new System.Drawing.Size(181, 22);
+            this.ToolbarSelectTimeCycleModifierButton.Size = new System.Drawing.Size(193, 22);
             this.ToolbarSelectTimeCycleModifierButton.Text = "Time Cycle Modifier";
             this.ToolbarSelectTimeCycleModifierButton.Click += new System.EventHandler(this.ToolbarSelectTimeCycleModifierButton_Click);
             // 
             // ToolbarSelectCarGeneratorButton
             // 
             this.ToolbarSelectCarGeneratorButton.Name = "ToolbarSelectCarGeneratorButton";
-            this.ToolbarSelectCarGeneratorButton.Size = new System.Drawing.Size(181, 22);
+            this.ToolbarSelectCarGeneratorButton.Size = new System.Drawing.Size(193, 22);
             this.ToolbarSelectCarGeneratorButton.Text = "Car Generator";
             this.ToolbarSelectCarGeneratorButton.Click += new System.EventHandler(this.ToolbarSelectCarGeneratorButton_Click);
             // 
             // ToolbarSelectGrassButton
             // 
             this.ToolbarSelectGrassButton.Name = "ToolbarSelectGrassButton";
-            this.ToolbarSelectGrassButton.Size = new System.Drawing.Size(181, 22);
+            this.ToolbarSelectGrassButton.Size = new System.Drawing.Size(193, 22);
             this.ToolbarSelectGrassButton.Text = "Grass";
             this.ToolbarSelectGrassButton.Click += new System.EventHandler(this.ToolbarSelectGrassButton_Click);
             // 
             // ToolbarSelectWaterQuadButton
             // 
             this.ToolbarSelectWaterQuadButton.Name = "ToolbarSelectWaterQuadButton";
-            this.ToolbarSelectWaterQuadButton.Size = new System.Drawing.Size(181, 22);
+            this.ToolbarSelectWaterQuadButton.Size = new System.Drawing.Size(193, 22);
             this.ToolbarSelectWaterQuadButton.Text = "Water Quad";
             this.ToolbarSelectWaterQuadButton.Click += new System.EventHandler(this.ToolbarSelectWaterQuadButton_Click);
             // 
             // ToolbarSelectCollisionButton
             // 
             this.ToolbarSelectCollisionButton.Name = "ToolbarSelectCollisionButton";
-            this.ToolbarSelectCollisionButton.Size = new System.Drawing.Size(181, 22);
+            this.ToolbarSelectCollisionButton.Size = new System.Drawing.Size(193, 22);
             this.ToolbarSelectCollisionButton.Text = "Collision";
             this.ToolbarSelectCollisionButton.Click += new System.EventHandler(this.ToolbarSelectCollisionButton_Click);
             // 
             // ToolbarSelectNavMeshButton
             // 
             this.ToolbarSelectNavMeshButton.Name = "ToolbarSelectNavMeshButton";
-            this.ToolbarSelectNavMeshButton.Size = new System.Drawing.Size(181, 22);
+            this.ToolbarSelectNavMeshButton.Size = new System.Drawing.Size(193, 22);
             this.ToolbarSelectNavMeshButton.Text = "Nav Mesh";
             this.ToolbarSelectNavMeshButton.Click += new System.EventHandler(this.ToolbarSelectNavMeshButton_Click);
             // 
             // ToolbarSelectPathButton
             // 
             this.ToolbarSelectPathButton.Name = "ToolbarSelectPathButton";
-            this.ToolbarSelectPathButton.Size = new System.Drawing.Size(181, 22);
+            this.ToolbarSelectPathButton.Size = new System.Drawing.Size(193, 22);
             this.ToolbarSelectPathButton.Text = "Traffic Path";
             this.ToolbarSelectPathButton.Click += new System.EventHandler(this.ToolbarSelectPathButton_Click);
             // 
             // ToolbarSelectTrainTrackButton
             // 
             this.ToolbarSelectTrainTrackButton.Name = "ToolbarSelectTrainTrackButton";
-            this.ToolbarSelectTrainTrackButton.Size = new System.Drawing.Size(181, 22);
+            this.ToolbarSelectTrainTrackButton.Size = new System.Drawing.Size(193, 22);
             this.ToolbarSelectTrainTrackButton.Text = "Train Track";
             this.ToolbarSelectTrainTrackButton.Click += new System.EventHandler(this.ToolbarSelectTrainTrackButton_Click);
             // 
             // ToolbarSelectDistantLodLightsButton
             // 
             this.ToolbarSelectDistantLodLightsButton.Name = "ToolbarSelectDistantLodLightsButton";
-            this.ToolbarSelectDistantLodLightsButton.Size = new System.Drawing.Size(181, 22);
+            this.ToolbarSelectDistantLodLightsButton.Size = new System.Drawing.Size(193, 22);
             this.ToolbarSelectDistantLodLightsButton.Text = "Distant Lod Lights";
             this.ToolbarSelectDistantLodLightsButton.Click += new System.EventHandler(this.ToolbarSelectDistantLodLightsButton_Click);
             // 
             // ToolbarSelectMloInstanceButton
             // 
             this.ToolbarSelectMloInstanceButton.Name = "ToolbarSelectMloInstanceButton";
-            this.ToolbarSelectMloInstanceButton.Size = new System.Drawing.Size(181, 22);
+            this.ToolbarSelectMloInstanceButton.Size = new System.Drawing.Size(193, 22);
             this.ToolbarSelectMloInstanceButton.Text = "Interior Instance";
             this.ToolbarSelectMloInstanceButton.Click += new System.EventHandler(this.ToolbarSelectMloInstanceButton_Click);
             // 
             // ToolbarSelectScenarioButton
             // 
             this.ToolbarSelectScenarioButton.Name = "ToolbarSelectScenarioButton";
-            this.ToolbarSelectScenarioButton.Size = new System.Drawing.Size(181, 22);
+            this.ToolbarSelectScenarioButton.Size = new System.Drawing.Size(193, 22);
             this.ToolbarSelectScenarioButton.Text = "Scenario";
             this.ToolbarSelectScenarioButton.Click += new System.EventHandler(this.ToolbarSelectScenarioButton_Click);
             // 
             // ToolbarSelectAudioButton
             // 
             this.ToolbarSelectAudioButton.Name = "ToolbarSelectAudioButton";
-            this.ToolbarSelectAudioButton.Size = new System.Drawing.Size(181, 22);
+            this.ToolbarSelectAudioButton.Size = new System.Drawing.Size(193, 22);
             this.ToolbarSelectAudioButton.Text = "Audio";
             this.ToolbarSelectAudioButton.Click += new System.EventHandler(this.ToolbarSelectAudioButton_Click);
             // 
@@ -3007,7 +3012,7 @@ namespace CodeWalker
             this.ToolbarObjectSpaceButton.CheckState = System.Windows.Forms.CheckState.Checked;
             this.ToolbarObjectSpaceButton.Image = ((System.Drawing.Image)(resources.GetObject("ToolbarObjectSpaceButton.Image")));
             this.ToolbarObjectSpaceButton.Name = "ToolbarObjectSpaceButton";
-            this.ToolbarObjectSpaceButton.Size = new System.Drawing.Size(142, 22);
+            this.ToolbarObjectSpaceButton.Size = new System.Drawing.Size(152, 22);
             this.ToolbarObjectSpaceButton.Text = "Object space";
             this.ToolbarObjectSpaceButton.Click += new System.EventHandler(this.ToolbarObjectSpaceButton_Click);
             // 
@@ -3015,7 +3020,7 @@ namespace CodeWalker
             // 
             this.ToolbarWorldSpaceButton.Image = ((System.Drawing.Image)(resources.GetObject("ToolbarWorldSpaceButton.Image")));
             this.ToolbarWorldSpaceButton.Name = "ToolbarWorldSpaceButton";
-            this.ToolbarWorldSpaceButton.Size = new System.Drawing.Size(142, 22);
+            this.ToolbarWorldSpaceButton.Size = new System.Drawing.Size(152, 22);
             this.ToolbarWorldSpaceButton.Text = "World space";
             this.ToolbarWorldSpaceButton.Click += new System.EventHandler(this.ToolbarWorldSpaceButton_Click);
             // 
@@ -3038,7 +3043,7 @@ namespace CodeWalker
             // 
             this.ToolbarSnapToGroundButton.Image = ((System.Drawing.Image)(resources.GetObject("ToolbarSnapToGroundButton.Image")));
             this.ToolbarSnapToGroundButton.Name = "ToolbarSnapToGroundButton";
-            this.ToolbarSnapToGroundButton.Size = new System.Drawing.Size(205, 22);
+            this.ToolbarSnapToGroundButton.Size = new System.Drawing.Size(224, 22);
             this.ToolbarSnapToGroundButton.Text = "Snap to Ground";
             this.ToolbarSnapToGroundButton.Click += new System.EventHandler(this.ToolbarSnapToGroundButton_Click);
             // 
@@ -3046,7 +3051,7 @@ namespace CodeWalker
             // 
             this.ToolbarSnapToGridButton.Image = ((System.Drawing.Image)(resources.GetObject("ToolbarSnapToGridButton.Image")));
             this.ToolbarSnapToGridButton.Name = "ToolbarSnapToGridButton";
-            this.ToolbarSnapToGridButton.Size = new System.Drawing.Size(205, 22);
+            this.ToolbarSnapToGridButton.Size = new System.Drawing.Size(224, 22);
             this.ToolbarSnapToGridButton.Text = "Snap to Grid";
             this.ToolbarSnapToGridButton.Click += new System.EventHandler(this.ToolbarSnapToGridButton_Click);
             // 
@@ -3054,7 +3059,7 @@ namespace CodeWalker
             // 
             this.ToolbarSnapToGroundGridButton.Image = ((System.Drawing.Image)(resources.GetObject("ToolbarSnapToGroundGridButton.Image")));
             this.ToolbarSnapToGroundGridButton.Name = "ToolbarSnapToGroundGridButton";
-            this.ToolbarSnapToGroundGridButton.Size = new System.Drawing.Size(205, 22);
+            this.ToolbarSnapToGroundGridButton.Size = new System.Drawing.Size(224, 22);
             this.ToolbarSnapToGroundGridButton.Text = "Snap to Grid and Ground";
             this.ToolbarSnapToGroundGridButton.Click += new System.EventHandler(this.ToolbarSnapToGroundGridButton_Click);
             // 
@@ -3079,7 +3084,7 @@ namespace CodeWalker
             // ToolbarUndoListButton
             // 
             this.ToolbarUndoListButton.Name = "ToolbarUndoListButton";
-            this.ToolbarUndoListButton.Size = new System.Drawing.Size(121, 22);
+            this.ToolbarUndoListButton.Size = new System.Drawing.Size(128, 22);
             this.ToolbarUndoListButton.Text = "Undo list";
             this.ToolbarUndoListButton.Click += new System.EventHandler(this.ToolbarUndoListButton_Click);
             // 
@@ -3099,7 +3104,7 @@ namespace CodeWalker
             // ToolbarRedoListButton
             // 
             this.ToolbarRedoListButton.Name = "ToolbarRedoListButton";
-            this.ToolbarRedoListButton.Size = new System.Drawing.Size(119, 22);
+            this.ToolbarRedoListButton.Size = new System.Drawing.Size(127, 22);
             this.ToolbarRedoListButton.Text = "Redo list";
             this.ToolbarRedoListButton.Click += new System.EventHandler(this.ToolbarRedoListButton_Click);
             // 
@@ -3210,7 +3215,7 @@ namespace CodeWalker
             this.ToolbarCameraPerspectiveButton.CheckState = System.Windows.Forms.CheckState.Checked;
             this.ToolbarCameraPerspectiveButton.Image = ((System.Drawing.Image)(resources.GetObject("ToolbarCameraPerspectiveButton.Image")));
             this.ToolbarCameraPerspectiveButton.Name = "ToolbarCameraPerspectiveButton";
-            this.ToolbarCameraPerspectiveButton.Size = new System.Drawing.Size(145, 22);
+            this.ToolbarCameraPerspectiveButton.Size = new System.Drawing.Size(154, 22);
             this.ToolbarCameraPerspectiveButton.Text = "Perspective";
             this.ToolbarCameraPerspectiveButton.Click += new System.EventHandler(this.ToolbarCameraPerspectiveButton_Click);
             // 
@@ -3218,7 +3223,7 @@ namespace CodeWalker
             // 
             this.ToolbarCameraMapViewButton.Image = ((System.Drawing.Image)(resources.GetObject("ToolbarCameraMapViewButton.Image")));
             this.ToolbarCameraMapViewButton.Name = "ToolbarCameraMapViewButton";
-            this.ToolbarCameraMapViewButton.Size = new System.Drawing.Size(145, 22);
+            this.ToolbarCameraMapViewButton.Size = new System.Drawing.Size(154, 22);
             this.ToolbarCameraMapViewButton.Text = "Map View";
             this.ToolbarCameraMapViewButton.Click += new System.EventHandler(this.ToolbarCameraMapViewButton_Click);
             // 
@@ -3226,7 +3231,7 @@ namespace CodeWalker
             // 
             this.ToolbarCameraOrthographicButton.Image = ((System.Drawing.Image)(resources.GetObject("ToolbarCameraOrthographicButton.Image")));
             this.ToolbarCameraOrthographicButton.Name = "ToolbarCameraOrthographicButton";
-            this.ToolbarCameraOrthographicButton.Size = new System.Drawing.Size(145, 22);
+            this.ToolbarCameraOrthographicButton.Size = new System.Drawing.Size(154, 22);
             this.ToolbarCameraOrthographicButton.Text = "Orthographic";
             this.ToolbarCameraOrthographicButton.Click += new System.EventHandler(this.ToolbarCameraOrthographicButton_Click);
             // 
@@ -3240,6 +3245,34 @@ namespace CodeWalker
             this.ToolbarPanel.Size = new System.Drawing.Size(557, 26);
             this.ToolbarPanel.TabIndex = 7;
             this.ToolbarPanel.Visible = false;
+            // 
+            // VSExtender
+            // 
+            this.VSExtender.DefaultRenderer = null;
+            // 
+            // ThemeComboBox
+            // 
+            this.ThemeComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.ThemeComboBox.FormattingEnabled = true;
+            this.ThemeComboBox.Items.AddRange(new object[] {
+            "Windows",
+            "Light",
+            "Blue",
+            "Dark"});
+            this.ThemeComboBox.Location = new System.Drawing.Point(58, 278);
+            this.ThemeComboBox.Name = "ThemeComboBox";
+            this.ThemeComboBox.Size = new System.Drawing.Size(136, 21);
+            this.ThemeComboBox.TabIndex = 67;
+            this.ThemeComboBox.SelectedIndexChanged += new System.EventHandler(this.ThemeComboBox_SelectedIndexChanged);
+            // 
+            // label31
+            // 
+            this.label31.AutoSize = true;
+            this.label31.Location = new System.Drawing.Point(3, 281);
+            this.label31.Name = "label31";
+            this.label31.Size = new System.Drawing.Size(49, 15);
+            this.label31.TabIndex = 68;
+            this.label31.Text = "Theme:";
             // 
             // WorldForm
             // 
@@ -3581,5 +3614,8 @@ namespace CodeWalker
         private System.Windows.Forms.ToolStripMenuItem ToolbarSnapToGroundGridButton;
         private System.Windows.Forms.NumericUpDown SnapGridSizeUpDown;
         private System.Windows.Forms.Label label26;
+        private WeifenLuo.WinFormsUI.Docking.VisualStudioToolStripExtender VSExtender;
+        private System.Windows.Forms.Label label31;
+        private System.Windows.Forms.ComboBox ThemeComboBox;
     }
 }

--- a/WorldForm.cs
+++ b/WorldForm.cs
@@ -4607,10 +4607,6 @@ namespace CodeWalker
             //called by the SettingsForm when it's closed.
             SettingsForm = null;
         }
-
-
-
-
         private bool CanMarkUndo()
         {
             if (SelectedItem.MultipleSelection) return true;

--- a/WorldForm.cs
+++ b/WorldForm.cs
@@ -15,6 +15,7 @@ using CodeWalker.Project;
 using CodeWalker.Rendering;
 using CodeWalker.GameFiles;
 using CodeWalker.Properties;
+using WeifenLuo.WinFormsUI.Docking;
 
 namespace CodeWalker
 {
@@ -204,10 +205,13 @@ namespace CodeWalker
 
         bool initedOk = false;
 
+        public ThemeBase Theme { get; private set; }
 
         public WorldForm()
         {
             InitializeComponent();
+
+            SetTheme(Settings.Default.WorldWindowTheme, false);
 
             Renderer = new Renderer(this, gameFileCache);
             camera = Renderer.camera;
@@ -290,6 +294,8 @@ namespace CodeWalker
 
             DlcLevelComboBox.SelectedIndex = 0; //show "<Loading...>" until DLC list is loaded
 
+            ThemeComboBox.SelectedItem = Settings.Default.WorldWindowTheme;
+
             UpdateToolbarShortcutsText();
 
 
@@ -299,7 +305,47 @@ namespace CodeWalker
             Renderer.Start();
         }
 
+        private void SetTheme(string themestr, bool changing = true)
+        {
+            Theme = null;
+            var version = VisualStudioToolStripExtender.VsVersion.Vs2015;
 
+            switch (themestr)
+            {
+                default:
+                case "Windows":
+                    //Theme = new VS2005Theme();
+                    version = VisualStudioToolStripExtender.VsVersion.Unknown;
+                    if (changing)
+                    {
+                        MessageBox.Show("Please restart Codewalker to change to the windows theme.");
+                    }
+                    break;
+                case "Blue":
+                    Theme = new VS2015BlueTheme();
+                    break;
+                case "Light":
+                    Theme = new VS2015LightTheme();
+                    break;
+                case "Dark":
+                    Theme = new VS2015DarkTheme();
+                    break;
+            }
+
+            if (changing)
+            {
+                Settings.Default.WorldWindowTheme = themestr;
+                Settings.Default.Save();
+            }
+
+            if (Theme != null)
+            {
+                VSExtender.SetStyle(StatusStrip, version, Theme);
+                VSExtender.SetStyle(Toolbar, version, Theme);
+
+                FormTheme.SetTheme(this, Theme);
+            }
+        }
 
         private MapIcon AddIcon(string name, string filename, int texw, int texh, float centerx, float centery, float scale)
         {
@@ -3905,6 +3951,7 @@ namespace CodeWalker
             if (InfoForm == null)
             {
                 InfoForm = new WorldInfoForm(this);
+                FormTheme.SetTheme(InfoForm, Theme);
                 InfoForm.SetSelection(SelectedItem, SelectedItems);
                 InfoForm.SetSelectionMode(SelectionModeStr, MouseSelectEnabled);
                 InfoForm.Show(this);
@@ -3960,6 +4007,7 @@ namespace CodeWalker
             if (SearchForm == null)
             {
                 SearchForm = new WorldSearchForm(this);
+                FormTheme.SetTheme(SearchForm, Theme);
                 SearchForm.Show(this);
             }
             else
@@ -4538,6 +4586,7 @@ namespace CodeWalker
             if (SettingsForm == null)
             {
                 SettingsForm = new SettingsForm(this);
+                FormTheme.SetTheme(SettingsForm, Theme);
                 SettingsForm.Show(this);
             }
             else
@@ -6605,6 +6654,7 @@ namespace CodeWalker
         private void AboutButton_Click(object sender, EventArgs e)
         {
             AboutForm f = new AboutForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show(this);
         }
 
@@ -6616,6 +6666,7 @@ namespace CodeWalker
         private void ToolsMenuRPFBrowser_Click(object sender, EventArgs e)
         {
             BrowseForm f = new BrowseForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show(this);
         }
 
@@ -6643,42 +6694,49 @@ namespace CodeWalker
         private void ToolsMenuBinarySearch_Click(object sender, EventArgs e)
         {
             BinarySearchForm f = new BinarySearchForm(gameFileCache);
+            FormTheme.SetTheme(f, Theme);
             f.Show(this);
         }
 
         private void ToolsMenuJenkGen_Click(object sender, EventArgs e)
         {
             JenkGenForm f = new JenkGenForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show(this);
         }
 
         private void ToolsMenuJenkInd_Click(object sender, EventArgs e)
         {
             JenkIndForm f = new JenkIndForm(gameFileCache);
+            FormTheme.SetTheme(f, Theme);
             f.Show(this);
         }
 
         private void ToolsMenuExtractScripts_Click(object sender, EventArgs e)
         {
             ExtractScriptsForm f = new ExtractScriptsForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show(this);
         }
 
         private void ToolsMenuExtractTextures_Click(object sender, EventArgs e)
         {
             ExtractTexForm f = new ExtractTexForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show(this);
         }
 
         private void ToolsMenuExtractRawFiles_Click(object sender, EventArgs e)
         {
             ExtractRawForm f = new ExtractRawForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show(this);
         }
 
         private void ToolsMenuExtractShaders_Click(object sender, EventArgs e)
         {
             ExtractShadersForm f = new ExtractShadersForm();
+            FormTheme.SetTheme(f, Theme);
             f.Show(this);
         }
 
@@ -7477,6 +7535,11 @@ namespace CodeWalker
         private void SnapGridSizeUpDown_ValueChanged(object sender, EventArgs e)
         {
             SnapGridSize = (float)SnapGridSizeUpDown.Value;
+        }
+
+        private void ThemeComboBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            SetTheme(ThemeComboBox.Text);
         }
     }
 

--- a/WorldForm.resx
+++ b/WorldForm.resx
@@ -170,7 +170,7 @@ ufo
   <data name="ToolbarNewButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADESURBVDhPzZI7DgIhGIQ5grUnsPQMnMgLWMo1bDyJiYUV
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAADESURBVDhPzZI7DgIhGIQ5grUnsPQMnMgLWMo1bDyJiYUV
         h7CxEo1Aiw7+E9ldWF+Nk0w2wMy3/z5UqRDCwjk3iTEmGmvsS6Ste2gtJYvrdjklJK9xLtGhcAeEdqtZ
         Ouw3uUgA1tgXSH0SGdsyfD0dcwHXAmqRk0pXCNMsN+y893OpPYVDjFw8d9JaD2yMqUNYgjkBCmd36bgJ
         6b+DMUAJkXr9K9QANM6QkfpD/f/gYwCESfgnfgWg/gcw5peAdyzxX6TUDfMCML1omZa9AAAAAElFTkSu
@@ -180,7 +180,7 @@ ufo
   <data name="ToolbarOpenButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEcSURBVDhPlZKxqsIwFIb7Bvc+idxHuPQVXFpQcOhe8Amc
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAAEcSURBVDhPlZKxqsIwFIb7Bvc+idxHuPQVXFpQcOhe8Amc
         OqqzCBdU6HQfQIfunVwKoi7FQQeF9GrajufmhDYkTaMY+EjPyf//TZtY9aCUfhVFQRggQbBfSV4PFJ8v
         GekMf8HqzqE3jXhIhRwsqKyWxYpJ3bzcMpBD4jgG27Y1RACaZ+sEPvoLbmqCa/f7AzLyJ2gGcDO+bXe6
         ajugDypMiBJQluU3f2DiZ+YmT3eANWIyIyKgFsv/AOs2k4wSgIXneRBFEaRpyhew10ZbwNb3fU1oYrPe
@@ -191,7 +191,7 @@ ufo
   <data name="ToolbarSaveButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABRSURBVDhPY6AK+Pbt239S8NevX+dDtUIASNDJyQmOP7z/
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAABRSURBVDhPY6AK+Pbt239S8NevX+dDtUIASNDJyQmOP7z/
         CMfIYiC6ra0N0xBSDABhmCFQ7aQbAMJEG4CMkdXQ1gBi8KgBg9IAcjBUOyWAgQEAoTb4kYkPBE8AAAAA
         SUVORK5CYII=
 </value>
@@ -199,7 +199,7 @@ ufo
   <data name="ToolbarSaveAllButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAB2SURBVDhP7ZCxDcAgDAQZKTMwnBdiMIJk0SZ6YksoYEOR
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAAB2SURBVDhP7ZCxDcAgDAQZKTMwnBdiMIJk0SZ6YksoYEOR
         Mi8ddvFc4WCl1no5ZGY+pDoPijHGxplLQ3ciWks8AaZKpD5mJuhFAB2pj+kFFt8I8FiklKYfFXTcY+FQ
         nmQpwPQkpqAXadFi/1hWfsEj2EHqr4RwAzbn8IoLYvtxAAAAAElFTkSuQmCC
 </value>
@@ -207,7 +207,7 @@ ufo
   <data name="ToolbarSelectButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACRSURBVDhPtY7bCcAgDEUdoaN0hOIWbtMvF/Lflfzx8dl6
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAACRSURBVDhPtY7bCcAgDEUdoaN0hOIWbtMvF/Lflfzx8dl6
         JSmlKNTQHgg+uDmJ+pyc81ErxBhX+poDAmutXAKB1louYYFYcheIJE/BtKQnmJKMBCiWULQPCxA2xrS7
         9x6NV1G0DwI06XDONQFE9R0qC8XG0JRQStlw8haQpZR2ir0DDaItGITRRFu1mt7iZ5Q6AVRB/GG9LRsl
         AAAAAElFTkSuQmCC
@@ -216,7 +216,7 @@ ufo
   <data name="ToolbarMoveButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACrSURBVDhPpVJbDoAgDONInoHD8c9J/SH8Kl02rZORGJs0
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAACrSURBVDhPpVJbDoAgDONInoHD8c9J/SH8Kl02rZORGJs0
         DNaWh6YZWmtb730vpRwgaqxpew0255yFn0K82YeoLMYQXQY2Y0RPZU/YsSEAdbcrgNeU93X8nVUoYRww
         00jIpLGkD0m24AnxrGbC+z8Ax7CQWquIVzQtxjHfo0cU2k429+bXl2AhRg7g4MH4rzSj7cY1eiqLgXQ2
         cwh6Kovh34TN4bE9OGRtTukExpYH+BWfUFQAAAAASUVORK5CYII=
@@ -225,7 +225,7 @@ ufo
   <data name="ToolbarRotateButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAFRSURBVDhPfZMxboNAEEU5Qo6QI+QIET1SWncp6OmpUrm1
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAAFRSURBVDhPfZMxboNAEEU5Qo6QI+QIET1SWncp6OmpUrm1
         6JFSuuQGuKaioQ89xRYYKDfz1jt4TYhX+trRnz9/2Z0h+m9N0/Q1z7MFxJ5+vpZleRfx9ziOP03T2MPh
         4EAMRw6Nl9+XkK+SvHDaMAy2KAobx/ED4Mj5L7oYY17WYiENApJd19k0Tf8YwJFDU5Ylu3iIiQQVBCKS
         SZLYuq6dSIuJ4cihUY4rYbAKwzjPc3d3QLynIV4NjsfjQxJwIgg5NGg1dgacIHu7NdgDGoHxNTcDf7oz
@@ -237,7 +237,7 @@ ufo
   <data name="ToolbarScaleButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAB4SURBVDhP3ZC7DcAgDEQZKTMwHOvSIFriS7BlEB+HMic9
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAAB4SURBVDhP3ZC7DcAgDEQZKTMwHOvSIFriS7BlEB+HMic9
         QJbvFThLUkpXzjkSpaeuzMPlEELx3jdsBauyCHBY6UWYPQI93KEljQD3jL6EGzN6x0bASyNYwkKU8Udm
         gd6TMnIikDJyIqjVNz8T7FgKrAwFX6lVinM3aJ05lWDPRRcAAAAASUVORK5CYII=
 </value>
@@ -264,7 +264,7 @@ ufo
   <data name="ToolbarTransformSpaceButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAB0SURBVDhP7ZNBCoAgEEXnSJ3BqxmetNpaMLhVv5DNRJS2
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAAB0SURBVDhP7ZNBCoAgEEXnSJ3BqxmetNpaMLhVv5DNRJS2
         CxIeuvA9XSjtg5mHEILPxB6U7JyLxphmSkDK1o5x9dst87SUfTXwRsYsA+paT0BGDGsVOJ92hdz3Bz4f
         wGPC48uu7w5IGd+gBlpRMgYCnRwyESUj3CsQkYNFDwAAAABJRU5ErkJggg==
 </value>
@@ -300,7 +300,7 @@ ufo
   <data name="ToolbarSnapButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACtSURBVDhPrZBBEsIgEAR5Gy/wFV55T/wHr+KgHuCKNsVY
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAACtSURBVDhPrZBBEsIgEAR5Gy/wFV55T/wHr+KgHuCKNsVY
         ZI2JiU7VVIVlp7OL+1mllIr7cb8Ie++PQwQYITnnM24NWxoBgsQYm/l+gk699bMsRA4h1JTSPsg0Xert
         em/mGwh3vW1Z7MvIABSWqXG3+iZHAEw1m4wD49oVANgVOL/VeSgeDAiX1mpWeKy9BIQiI+OxWQF77tG5
         2Fc729BmeElf/3lNhORe+oecewDObEqX49RqCgAAAABJRU5ErkJggg==
@@ -309,7 +309,7 @@ ufo
   <data name="ToolbarUndoButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEfSURBVDhPjVK7DgFBFN0/4A/4AvEJfkAi0ZLoNArR6hUq
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAAEfSURBVDhPjVK7DgFBFN0/4A/4AvEJfkAi0ZLoNArR6hUq
         tUgkElGJ1jYaDYVsI9Fq2EYyin2Ua864d9g1u/YkJ5nHOfcxcy2G53nVIAiEZBSGYdn3/TnviQJnuCPL
         BzDf3aeoDNZaPFweo0J7EVnNmSLWOMMd9GR9AyaYIXQfT702kZKIWCUIwIJSd6XX9dE2sk9XRaz5HJWg
         HbLHAzCn9pnbURklHQ6CdnBGdnMAsDXZKSF6lhkbqITvlIdhCvBthuZvAAO1WQhRlPv0FrKAIBCjIs7+
@@ -320,7 +320,7 @@ ufo
   <data name="ToolbarRedoButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEgSURBVDhPrZK9agJBFIXnDZJH8AkkLxIQbCP4AKls01tY
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAAEgSURBVDhPrZK9agJBFIXnDZJH8AkkLxIQbCP4AKls01tY
         WS+CEEiRQmyzjY1NLGQbQbCyUZvAbLE/5TjfMHezrLsbhBy4MHPvPWfuz6gy8jzvpGk6z7JMWzPeND4b
         G8o9SZInT/kFzvMl1m8fG/MweDeqP3PGGR/kcHs0L9PVrQgvQ+6OFgWxasQ+1wd3FhFPV4oSeUWSn8df
         7jWMs/jLlVGRpyuFmgQh2HuEjyQsCHcFsUmgCHzvT8ZW1KNHRJraahSgbATwy2DrRKoCNy1orR+JSSUQ
@@ -331,7 +331,7 @@ ufo
   <data name="ToolbarInfoWindowButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABSSURBVDhPtcxBCgAgCETRzub971Jt3BoGBpGhGS4eM6tf
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAABSSURBVDhPtcxBCgAgCETRzub971Jt3BoGBpGhGS4eM6tf
         EJF+zAAAhGyBVvuTa0A+r8YMeOUF5PNqzIBXXkA+r8YMeOUF5PNqzIDXEYhYgTikAQEeMEa6imiVAAAA
         AElFTkSuQmCC
 </value>
@@ -339,7 +339,7 @@ ufo
   <data name="ToolbarProjectWindowButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPlVM9ixpRFJ2fkJ+wPyE/ISgqCEoQBBtBMjYi
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAAIDSURBVDhPlVM9ixpRFJ2fkJ+wPyE/ISgqCEoQBBtBMjYi
         jmunhSCMWO4iiLhBWCwEq1goSLYwItlCBG20MBZRSGLn7OJXefLOZWaza7JFLrx5M/fcc+59797Rntvp
         dHp3OBxu7c//N0X+cjweQSHbRdGY8rVtjPulZVlvbPiPMXA8HqNUKoHBDFKEqTLUajUUi0XBut0ulN/a
         7/dvbaqm2cFWKpWCy+XCaDSSoEqlgmQyiVwuh2w2i0QigVAohHQ6LbhKeiECKmOh3+/D7/eLQDwex3A4
@@ -354,7 +354,7 @@ ufo
   <data name="ToolbarAddItemButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADpSURBVDhPjVIxEoJADOQpPsLCmp5f8ABL/II/wKGTT0jj
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAADpSURBVDhPjVIxEoJADOQpPsLCmp5f8ABL/II/wKGTT0jj
         J2jUVm3RAihP9mRnYu4ymJmdySzZvYQkYQzD4CTA9X2/nfIOQO4LrYBos197IJ8E57ZtXZ7nHsjBjeO4
         miXfQDEhDYjm1HhkWeaqqgL3240UauDbq3t7PO5PVxS7sJt/DQjdzeII2gAoy4NL09R/nwcJf+L1cguE
         4DBGfazjBhIspBg5OBpHDUBSIEXaDPjLgIUWHzXAunShNkBNzKDDarAirMoyCNbIwFHI88XcfAkwD0kH
@@ -364,7 +364,7 @@ ufo
   <data name="ToolbarDeleteItemButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAFySURBVDhPhVI9S8RAEN0/4D+wsLKwtbKTg2CV1sI6YGth
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAAFySURBVDhPhVI9S8RAEN0/4D+wsLKwtbKTg2CV1sI6YGth
         cbb+ALE9DYgYg4XNWSh3CGIrggjh8NRSTyVFTMR8QMKYN7prTLL4YLLJZN6bmZ0RWZbR5OaK/Mcx5XlO
         AM7w7ZV9cRxTFEWfJdZEGxCwPztFx4tzJemFpGDfXODTcRyyLIs8z6NS5CJJkpkf6jdKB12uWyxyvrpM
         o6M9cuen+YTYcDBkM02TbNtGRcGfaoqioKoI7HZ3m9I05Xbeg5Dt+WlC3e5GsxqdAFrj/sNIicDq1Qhc
@@ -376,7 +376,7 @@ ufo
   <data name="ToolbarCopyButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACZSURBVDhPzZLLDYYgEIQpwZq4UwCtcLIDS7MQDj744YqM
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAACZSURBVDhPzZLLDYYgEIQpwZq4UwCtcLIDS7MQDj744YqM
         WR8hu/mN0cRJJgac/WCi6jWllLrizHgoaigmC2FjTNZa77bWZu89ID3FZAGAoXGYdmPtnFtvQjFZHGCD
         sICyyXYO4XcZIHae53ANgJf1aVvnW4DzAJ4wbnkLcHaMsaWxQ/8AFJP1CKD+CrDYuVYJSf8+3/kjUmoB
         0WKNJAuziQ0AAAAASUVORK5CYII=
@@ -385,7 +385,7 @@ ufo
   <data name="ToolbarPasteButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACKSURBVDhP7Y3LDYAgEEQpwVKsgSoojl4swSbUCwc0Aa7q
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAACKSURBVDhP7Y3LDYAgEEQpwVKsgSoojl4swSbUCwc0Aa7q
         4BJN+IjGo5O8ZJndGVhKxpjWWts551aih0fre+0BLaVchRAezPB2NXSSV/gVwXGYPJiVUt6ns1ghCDjn
         UQG86w3FToVgDcWCWS9Fvi/Ao0RVAcwUjwpyhzmf4n8BFApS5HZRwRuONGMbrIJ1JIN8O2QAAAAASUVO
         RK5CYII=
@@ -429,7 +429,7 @@ ufo
   <data name="ToolbarCameraModeButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEvSURBVDhP3dK/K0dRGMfxKxRJopCSEkLya/guUhQRmQwG
+        YQUAAAAJcEhZcwAADuoAAA7qAaOKY3EAAAEvSURBVDhP3dK/K0dRGMfxKxRJopCSEkLya/guUhQRmQwG
         WfwIkYySgYUSKUKJlOK/MBoMFMofYLUIsfJ+f3NuF3+A8tRree5zP/fcc070f6oHT/jAPTqQj6WvXvCM
         TZQgG3H58gFGcYVLtGIN15jBNDbwiGNUIg4pQx8GsQuHhrCDW8yjHyns4Q0DcCXpykM5bFzgHGPYxw1G
         UIVMtMHfWUUj4nIg/KurGIYrSAZYOXDGlbhXcZlegUO8Yxzb+BlQAwNW0G0jVAYK0AwHtnCEOyQDZvGC
@@ -437,6 +437,9 @@ ufo
         5ZF+uwdZKEYtmuBGFSIXhtejBe5PHX7dxL+qKPoEppRHcXOtiDsAAAAASUVORK5CYII=
 </value>
   </data>
+  <metadata name="VSExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>677, 10</value>
+  </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAMAICAAAAAAGACoDAAANgAAABAQAAAAABgAaAMAAN4MAABAQAAAAAAYACgyAABGEAAAKAAAACAA


### PR DESCRIPTION
I fixed all errors you said were wrong from the last one. 

I have added a combo box and label that lets you change the theme of the world form. Depending on what theme the world form is in will open all other forms in that theme also.. for example if you have the worldform in "dark" theme then open the BinarySearch form it will set the binarysearch form to the "dark" theme also. Same with every other form except the RPF Explorer and Project Window. 

I also have added in themes for prompt.ShowDialog() it will load the prompt in what theme the prompts form is being loaded from for example... If you are in "dark" theme in RPF Explorer and create a new folder the prompt will be in "dark" theme.

While in the RPF Explorer If you open anything (modelform, metaform, etc.. ) then it will open with the RPF explorers current theme. For example if you are in "dark" theme while in RPF Explorer and open a ydr file then the model form will be in the "dark" theme also.

Explanation of file changes that you might wonder why:

Winforms.csproj - The reason this is changed is because I had to add a reference to the "FastColoredTextBox" dll so that I could use FormTheme.SetTheme() and set FastColoredTextBoxes for example in the MetaForm.

Settings.Designer - I changed this to add in the WorldWindowTheme Setting to save the settings.

WorldForm.resx - I added the VS Extender so that I could set the styles of all toolsstrips in the worldform.

Also all things I added with blue theme are disabled.
