### PR TITLE
show all viehicles feature

### DIFF
--- a/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs
+++ b/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs
@@ -56,6 +56,9 @@ namespace CodeWalker.GameFiles
 
         //fields used by the editor:
         public bool HasChanged { get; set; } = false;
+        public bool Custom = false;
+
+
         public List<string> SaveWarnings = null;
 
 
@@ -2152,7 +2155,6 @@ namespace CodeWalker.GameFiles
         public Vector3 BBMax { get; set; }
 
         public YmapFile Ymap { get; set; }
-
 
         public YmapCarGen(YmapFile ymap, CCarGen cargen)
         {

--- a/Project/ProjectForm.cs
+++ b/Project/ProjectForm.cs
@@ -5,14 +5,9 @@ using CodeWalker.World;
 using SharpDX;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using WeifenLuo.WinFormsUI.Docking;
 
@@ -101,7 +96,8 @@ namespace CodeWalker.Project
             else
             {
                 GameFileCache = GameFileCacheFactory.Create();
-                new Thread(new ThreadStart(() => {
+                new Thread(new ThreadStart(() =>
+                {
                     GTA5Keys.LoadFromPath(GTAFolder.CurrentGTAFolder, Settings.Default.Key);
                     GameFileCache.Init(UpdateStatus, UpdateError);
                     RpfMan = GameFileCache.RpfMan;
@@ -276,7 +272,7 @@ namespace CodeWalker.Project
                 PreviewPanel = panel;
             }
         }
-        public void ShowPanel<T>(bool promote, Func<T> createFunc, Action<T> updateAction, Func<T,bool> findFunc) where T : ProjectPanel
+        public void ShowPanel<T>(bool promote, Func<T> createFunc, Action<T> updateAction, Func<T, bool> findFunc) where T : ProjectPanel
         {
             T found = FindPanel(findFunc);
             if ((found != null) && (found != PreviewPanel))
@@ -705,7 +701,7 @@ namespace CodeWalker.Project
             }
         }
 
-        private void ClosePanel<T>(Func<T,bool> findFunc) where T : ProjectPanel
+        private void ClosePanel<T>(Func<T, bool> findFunc) where T : ProjectPanel
         {
             var panel = FindPanel(findFunc);
             if (PreviewPanel == panel)
@@ -1594,7 +1590,7 @@ namespace CodeWalker.Project
             batch.Position = (batch.AABBMin + batch.AABBMax) * 0.5f;
             batch.Radius = (batch.AABBMax - batch.AABBMin).Length() * 0.5f;
             batch.Ymap = CurrentYmapFile;
-            
+
             if (WorldForm != null)
             {
                 lock (WorldForm.RenderSyncRoot) //don't try to do this while rendering...
@@ -1740,7 +1736,6 @@ namespace CodeWalker.Project
 
 
             YmapCarGen cg = new YmapCarGen(CurrentYmapFile, ccg);
-
             if (WorldForm != null)
             {
                 lock (WorldForm.RenderSyncRoot) //don't try to do this while rendering...
@@ -2200,7 +2195,7 @@ namespace CodeWalker.Project
                         } rooms.");
                 return;
             }
-            
+
             float spawndist = 5.0f; //use archetype BSradius if starting with a copy...
             if (copy != null)
             {
@@ -2258,7 +2253,7 @@ namespace CodeWalker.Project
                     mloArch.AddEntity(outEnt, roomIndex);
                 }
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 MessageBox.Show(this, e.Message, "Create MLO Entity Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
@@ -2447,10 +2442,10 @@ namespace CodeWalker.Project
             if (CurrentYndFile == null) return;
 
             // Check that vehicle nodes and ped nodes add up to total nodes
-            if(CurrentYndFile.NodeDictionary != null && (CurrentYndFile.NodeDictionary.NodesCountPed + CurrentYndFile.NodeDictionary.NodesCountVehicle != CurrentYndFile.NodeDictionary.NodesCount))
+            if (CurrentYndFile.NodeDictionary != null && (CurrentYndFile.NodeDictionary.NodesCountPed + CurrentYndFile.NodeDictionary.NodesCountVehicle != CurrentYndFile.NodeDictionary.NodesCount))
             {
                 var result = MessageBox.Show($"YND Area {CurrentYndFile.AreaID}: The total number of nodes ({CurrentYndFile.NodeDictionary.NodesCount}) does not match the total number of ped ({CurrentYndFile.NodeDictionary.NodesCountPed}) and vehicle ({CurrentYndFile.NodeDictionary.NodesCountVehicle}) nodes. You should manually adjust the number of nodes on the YND screen.\n\nDo you want to continue saving the YND file? Some of your nodes may not work in game.", $"Node count mismatch in Area {CurrentYndFile.AreaID}", MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2);
-                if(result == DialogResult.Cancel)
+                if (result == DialogResult.Cancel)
                 {
                     return;
                 }
@@ -4626,6 +4621,7 @@ namespace CodeWalker.Project
 
                     if (YmapExistsInProject(ymap))
                     {
+                        ymap.Custom = true;
                         if (ent != CurrentEntity)
                         {
                             ProjectExplorer?.TrySelectEntityTreeNode(ent);
@@ -5362,7 +5358,7 @@ namespace CodeWalker.Project
             byte[] data = File.ReadAllBytes(filename);
 
             ymap.Load(data);
-
+            ymap.Custom = true;
             ymap.InitYmapEntityArchetypes(GameFileCache); //this needs to be done after calling YmapFile.Load()
         }
         private void LoadYtypFromFile(YtypFile ytyp, string filename)

--- a/Rendering/Renderer.cs
+++ b/Rendering/Renderer.cs
@@ -6,9 +6,7 @@ using SharpDX.Direct3D11;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace CodeWalker.Rendering
 {
@@ -144,13 +142,7 @@ namespace CodeWalker.Rendering
         public List<RenderedBoundComposite> RenderedBoundComps = new List<RenderedBoundComposite>();
         public bool RenderedDrawablesListEnable = false; //whether or not to add rendered drawables to the list
         public bool RenderedBoundCompsListEnable = false; //whether or not to add rendered bound comps to the list
-
-
-
-
-
-
-
+        public bool renderCustomCars = false;
 
         public Renderer(DXForm form, GameFileCache cache)
         {
@@ -711,8 +703,8 @@ namespace CodeWalker.Rendering
                 SelectionLineVerts.Add(c[(i + 1) % c.Length]);
             }
 
-            SelectionLineVerts.Add(new VertexTypePC{Colour = col, Position = position});
-            SelectionLineVerts.Add(new VertexTypePC { Colour = col, Position = position + dir * 2f});
+            SelectionLineVerts.Add(new VertexTypePC { Colour = col, Position = position });
+            SelectionLineVerts.Add(new VertexTypePC { Colour = col, Position = position + dir * 2f });
         }
 
         public void RenderSelectionArrowOutline(Vector3 pos, Vector3 dir, Vector3 up, Quaternion ori, float len, float rad, uint colour)
@@ -1608,7 +1600,7 @@ namespace CodeWalker.Rendering
                 }
             }
 
-            if(renderentities)
+            if (renderentities)
             {
                 for (int i = 0; i < renderworldrenderables.Count; i++)
                 {
@@ -1625,9 +1617,12 @@ namespace CodeWalker.Rendering
                 for (int y = 0; y < VisibleYmaps.Count; y++)
                 {
                     var ymap = VisibleYmaps[y];
-                    if (ymap.CarGenerators == null) continue;
+                    if (ymap.CarGenerators == null || renderCustomCars && !ymap.Custom) continue;
                     for (int i = 0; i < ymap.CarGenerators.Length; i++)
+                    {
                         RenderCar(ymap.CarGenerators[i]);
+                    }
+
                 }
             }
 
@@ -1637,9 +1632,7 @@ namespace CodeWalker.Rendering
                 {
                     var ymap = VisibleYmaps[y];
                     if (ymap.GrassInstanceBatches != null)
-                    {
                         RenderYmapGrass(ymap);
-                    }
                 }
             }
             if (renderdistlodlights && timecycle.IsNightTime)
@@ -1973,6 +1966,9 @@ namespace CodeWalker.Rendering
             {
                 RenderYmapDistantLODLights(ymap);
             }
+            if (ymap.CarGenerators != null)
+                for (int i = 0; i < ymap.CarGenerators.Length; i++)
+                    RenderCar(ymap.CarGenerators[i]);
 
         }
         private bool RenderYmapLOD(YmapFile ymap, YmapEntityDef entity)

--- a/Rendering/Renderer.cs
+++ b/Rendering/Renderer.cs
@@ -102,6 +102,7 @@ namespace CodeWalker.Rendering
         public bool renderentities = true;
         public bool rendergrass = true;
         public bool renderdistlodlights = true;
+        public bool renderCars = false;
 
         public bool rendercollisionmeshes = Settings.Default.ShowCollisionMeshes;
         public bool rendercollisionmeshlayerdrawable = true;
@@ -1619,7 +1620,16 @@ namespace CodeWalker.Rendering
                 }
             }
 
-
+            if (renderCars)
+            {
+                for (int y = 0; y < VisibleYmaps.Count; y++)
+                {
+                    var ymap = VisibleYmaps[y];
+                    if (ymap.CarGenerators == null) continue;
+                    for (int i = 0; i < ymap.CarGenerators.Length; i++)
+                        RenderCar(ymap.CarGenerators[i]);
+                }
+            }
 
             if (rendergrass)
             {
@@ -1921,7 +1931,6 @@ namespace CodeWalker.Rendering
         {
             if (ymap == null) return;
             if (!ymap.Loaded) return;
-
             if ((ymap.AllEntities != null) && (ymap.RootEntities != null))
             {
                 if (usedynamiclod)
@@ -2408,10 +2417,8 @@ namespace CodeWalker.Rendering
 
 
 
-
-        public void RenderCar(Vector3 pos, Quaternion ori, MetaHash modelHash, MetaHash modelSetHash, bool valign = false)
+        private void _RenderCar(Vector3 pos, Quaternion ori, MetaHash modelHash, MetaHash modelSetHash, bool valign = false)
         {
-
             uint carhash = modelHash;
             if ((carhash == 0) && (modelSetHash != 0))
             {
@@ -2443,7 +2450,17 @@ namespace CodeWalker.Rendering
                 RenderFragment(null, SelectedCarGenEntity, caryft.Fragment, carhash);
             }
         }
-
+        public void RenderCar(Vector3 pos, Quaternion ori, MetaHash modelHash, MetaHash modelSetHash, bool valign = false)
+        {
+            _RenderCar(pos, ori, modelHash, modelSetHash, valign);
+        }
+        public void RenderCar(YmapCarGen cg, bool valign = false)
+        {
+            uint carhash = cg.CCarGen.carModel;
+            Quaternion cgtrn = Quaternion.RotationAxis(Vector3.UnitZ, (float)Math.PI * -0.5f); //car fragments currently need to be rotated 90 deg right...
+            Quaternion ori = Quaternion.Multiply(cg.Orientation, cgtrn);
+            _RenderCar(cg.Position, ori, cg._CCarGen.carModel, cg._CCarGen.popGroup, valign);
+        }
 
 
 

--- a/WorldForm.Designer.cs
+++ b/WorldForm.Designer.cs
@@ -63,6 +63,7 @@ namespace CodeWalker
             this.label15 = new System.Windows.Forms.Label();
             this.WorldMaxLodComboBox = new System.Windows.Forms.ComboBox();
             this.ViewYmapsTabPage = new System.Windows.Forms.TabPage();
+            this.ShowVehicleModelsCheckBox = new System.Windows.Forms.CheckBox();
             this.ShowYmapChildrenCheckBox = new System.Windows.Forms.CheckBox();
             this.label2 = new System.Windows.Forms.Label();
             this.DetailTrackBar = new System.Windows.Forms.TrackBar();
@@ -286,7 +287,7 @@ namespace CodeWalker
             this.ToolbarCameraMapViewButton = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolbarCameraOrthographicButton = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolbarPanel = new System.Windows.Forms.Panel();
-            this.ShowVehicleModelsCheckBox = new System.Windows.Forms.CheckBox();
+            this.ShowCustomVehicleModelsCheckBox = new System.Windows.Forms.CheckBox();
             this.StatusStrip.SuspendLayout();
             this.ToolsPanel.SuspendLayout();
             this.ToolsTabControl.SuspendLayout();
@@ -728,6 +729,7 @@ namespace CodeWalker
             // 
             // ViewYmapsTabPage
             // 
+            this.ViewYmapsTabPage.Controls.Add(this.ShowCustomVehicleModelsCheckBox);
             this.ViewYmapsTabPage.Controls.Add(this.ShowVehicleModelsCheckBox);
             this.ViewYmapsTabPage.Controls.Add(this.ShowYmapChildrenCheckBox);
             this.ViewYmapsTabPage.Controls.Add(this.label2);
@@ -741,6 +743,17 @@ namespace CodeWalker
             this.ViewYmapsTabPage.TabIndex = 1;
             this.ViewYmapsTabPage.Text = "Ymaps";
             this.ViewYmapsTabPage.UseVisualStyleBackColor = true;
+            // 
+            // ShowVehicleModelsCheckBox
+            // 
+            this.ShowVehicleModelsCheckBox.AutoSize = true;
+            this.ShowVehicleModelsCheckBox.Location = new System.Drawing.Point(6, 83);
+            this.ShowVehicleModelsCheckBox.Name = "ShowVehicleModelsCheckBox";
+            this.ShowVehicleModelsCheckBox.Size = new System.Drawing.Size(107, 17);
+            this.ShowVehicleModelsCheckBox.TabIndex = 37;
+            this.ShowVehicleModelsCheckBox.Text = "Show car models";
+            this.ShowVehicleModelsCheckBox.UseVisualStyleBackColor = true;
+            this.ShowVehicleModelsCheckBox.CheckedChanged += new System.EventHandler(this.ShowVehicleModels_CheckedChanged);
             // 
             // ShowYmapChildrenCheckBox
             // 
@@ -3270,16 +3283,16 @@ namespace CodeWalker
             this.ToolbarPanel.TabIndex = 7;
             this.ToolbarPanel.Visible = false;
             // 
-            // ShowVehicleModelsCheckBox
+            // ShowCustomVehicleModelsCheckBox
             // 
-            this.ShowVehicleModelsCheckBox.AutoSize = true;
-            this.ShowVehicleModelsCheckBox.Location = new System.Drawing.Point(6, 83);
-            this.ShowVehicleModelsCheckBox.Name = "ShowVehicleModelsCheckBox";
-            this.ShowVehicleModelsCheckBox.Size = new System.Drawing.Size(126, 17);
-            this.ShowVehicleModelsCheckBox.TabIndex = 37;
-            this.ShowVehicleModelsCheckBox.Text = "Show vehicle models";
-            this.ShowVehicleModelsCheckBox.UseVisualStyleBackColor = true;
-            this.ShowVehicleModelsCheckBox.CheckedChanged += new System.EventHandler(this.ShowVehicleModels_CheckedChanged);
+            this.ShowCustomVehicleModelsCheckBox.AutoSize = true;
+            this.ShowCustomVehicleModelsCheckBox.Location = new System.Drawing.Point(128, 83);
+            this.ShowCustomVehicleModelsCheckBox.Name = "ShowCustomVehicleModelsCheckBox";
+            this.ShowCustomVehicleModelsCheckBox.Size = new System.Drawing.Size(60, 17);
+            this.ShowCustomVehicleModelsCheckBox.TabIndex = 38;
+            this.ShowCustomVehicleModelsCheckBox.Text = "custom";
+            this.ShowCustomVehicleModelsCheckBox.UseVisualStyleBackColor = true;
+            this.ShowCustomVehicleModelsCheckBox.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
             // 
             // WorldForm
             // 
@@ -3624,5 +3637,6 @@ namespace CodeWalker
         private System.Windows.Forms.CheckBox RenderEntitiesCheckBox;
         private System.Windows.Forms.ToolStripMenuItem ToolbarSelectOcclusionButton;
         private System.Windows.Forms.CheckBox ShowVehicleModelsCheckBox;
+        private System.Windows.Forms.CheckBox ShowCustomVehicleModelsCheckBox;
     }
 }

--- a/WorldForm.Designer.cs
+++ b/WorldForm.Designer.cs
@@ -254,6 +254,7 @@ namespace CodeWalker
             this.ToolbarSelectMloInstanceButton = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolbarSelectScenarioButton = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolbarSelectAudioButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.ToolbarSelectOcclusionButton = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.ToolbarMoveButton = new System.Windows.Forms.ToolStripButton();
             this.ToolbarRotateButton = new System.Windows.Forms.ToolStripButton();
@@ -285,7 +286,7 @@ namespace CodeWalker
             this.ToolbarCameraMapViewButton = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolbarCameraOrthographicButton = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolbarPanel = new System.Windows.Forms.Panel();
-            this.ToolbarSelectOcclusionButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.ShowVehicleModelsCheckBox = new System.Windows.Forms.CheckBox();
             this.StatusStrip.SuspendLayout();
             this.ToolsPanel.SuspendLayout();
             this.ToolsTabControl.SuspendLayout();
@@ -727,6 +728,7 @@ namespace CodeWalker
             // 
             // ViewYmapsTabPage
             // 
+            this.ViewYmapsTabPage.Controls.Add(this.ShowVehicleModelsCheckBox);
             this.ViewYmapsTabPage.Controls.Add(this.ShowYmapChildrenCheckBox);
             this.ViewYmapsTabPage.Controls.Add(this.label2);
             this.ViewYmapsTabPage.Controls.Add(this.DetailTrackBar);
@@ -755,7 +757,7 @@ namespace CodeWalker
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(3, 88);
+            this.label2.Location = new System.Drawing.Point(3, 107);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(77, 13);
             this.label2.TabIndex = 8;
@@ -792,11 +794,11 @@ namespace CodeWalker
             this.YmapsTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.YmapsTextBox.Location = new System.Drawing.Point(0, 104);
+            this.YmapsTextBox.Location = new System.Drawing.Point(0, 123);
             this.YmapsTextBox.Multiline = true;
             this.YmapsTextBox.Name = "YmapsTextBox";
             this.YmapsTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this.YmapsTextBox.Size = new System.Drawing.Size(194, 444);
+            this.YmapsTextBox.Size = new System.Drawing.Size(194, 425);
             this.YmapsTextBox.TabIndex = 36;
             this.YmapsTextBox.Text = resources.GetString("YmapsTextBox.Text");
             this.YmapsTextBox.TextChanged += new System.EventHandler(this.YmapsTextBox_TextChanged);
@@ -2696,7 +2698,7 @@ namespace CodeWalker
             this.ToolbarCameraModeButton});
             this.Toolbar.Location = new System.Drawing.Point(1, 0);
             this.Toolbar.Name = "Toolbar";
-            this.Toolbar.Size = new System.Drawing.Size(585, 25);
+            this.Toolbar.Size = new System.Drawing.Size(554, 25);
             this.Toolbar.TabIndex = 6;
             this.Toolbar.Text = "toolStrip1";
             // 
@@ -2969,6 +2971,13 @@ namespace CodeWalker
             this.ToolbarSelectAudioButton.Size = new System.Drawing.Size(181, 22);
             this.ToolbarSelectAudioButton.Text = "Audio";
             this.ToolbarSelectAudioButton.Click += new System.EventHandler(this.ToolbarSelectAudioButton_Click);
+            // 
+            // ToolbarSelectOcclusionButton
+            // 
+            this.ToolbarSelectOcclusionButton.Name = "ToolbarSelectOcclusionButton";
+            this.ToolbarSelectOcclusionButton.Size = new System.Drawing.Size(181, 22);
+            this.ToolbarSelectOcclusionButton.Text = "Occlusion";
+            this.ToolbarSelectOcclusionButton.Click += new System.EventHandler(this.ToolbarSelectOcclusionButton_Click);
             // 
             // toolStripSeparator1
             // 
@@ -3261,12 +3270,16 @@ namespace CodeWalker
             this.ToolbarPanel.TabIndex = 7;
             this.ToolbarPanel.Visible = false;
             // 
-            // ToolbarSelectOcclusionButton
+            // ShowVehicleModelsCheckBox
             // 
-            this.ToolbarSelectOcclusionButton.Name = "ToolbarSelectOcclusionButton";
-            this.ToolbarSelectOcclusionButton.Size = new System.Drawing.Size(181, 22);
-            this.ToolbarSelectOcclusionButton.Text = "Occlusion";
-            this.ToolbarSelectOcclusionButton.Click += new System.EventHandler(this.ToolbarSelectOcclusionButton_Click);
+            this.ShowVehicleModelsCheckBox.AutoSize = true;
+            this.ShowVehicleModelsCheckBox.Location = new System.Drawing.Point(6, 83);
+            this.ShowVehicleModelsCheckBox.Name = "ShowVehicleModelsCheckBox";
+            this.ShowVehicleModelsCheckBox.Size = new System.Drawing.Size(126, 17);
+            this.ShowVehicleModelsCheckBox.TabIndex = 37;
+            this.ShowVehicleModelsCheckBox.Text = "Show vehicle models";
+            this.ShowVehicleModelsCheckBox.UseVisualStyleBackColor = true;
+            this.ShowVehicleModelsCheckBox.CheckedChanged += new System.EventHandler(this.ShowVehicleModels_CheckedChanged);
             // 
             // WorldForm
             // 
@@ -3610,5 +3623,6 @@ namespace CodeWalker
         private System.Windows.Forms.Label label26;
         private System.Windows.Forms.CheckBox RenderEntitiesCheckBox;
         private System.Windows.Forms.ToolStripMenuItem ToolbarSelectOcclusionButton;
+        private System.Windows.Forms.CheckBox ShowVehicleModelsCheckBox;
     }
 }

--- a/WorldForm.cs
+++ b/WorldForm.cs
@@ -1,19 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using System.Threading;
-using System.Diagnostics;
+﻿using CodeWalker.GameFiles;
+using CodeWalker.Project;
+using CodeWalker.Properties;
+using CodeWalker.Rendering;
+using CodeWalker.World;
 using SharpDX;
 using SharpDX.XInput;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
 using Device = SharpDX.Direct3D11.Device;
 using DeviceContext = SharpDX.Direct3D11.DeviceContext;
-using CodeWalker.World;
-using CodeWalker.Project;
-using CodeWalker.Rendering;
-using CodeWalker.GameFiles;
-using CodeWalker.Properties;
 
 namespace CodeWalker
 {
@@ -103,7 +103,7 @@ namespace CodeWalker
 
 
 
-        
+
 
 
 
@@ -350,7 +350,7 @@ namespace CodeWalker
             }
 
             camera.FollowEntity = camEntity;
-            camEntity.Position = (startupviewmode!=2) ? prevworldpos : Vector3.Zero;
+            camEntity.Position = (startupviewmode != 2) ? prevworldpos : Vector3.Zero;
             camEntity.Orientation = Quaternion.LookAtLH(Vector3.Zero, Vector3.Up, Vector3.ForwardLH);
 
             space.AddPersistentEntity(pedEntity);
@@ -1154,7 +1154,7 @@ namespace CodeWalker
                 UpdateMousedLabel(text);
             }
 
-            if(!CurMouseHit.HasHit)
+            if (!CurMouseHit.HasHit)
             { return; }
 
 
@@ -1312,17 +1312,13 @@ namespace CodeWalker
             {
                 var cg = selectionItem.CarGenerator;
                 camrel = cg.Position - camera.Position;
-                ori = cg.Orientation;
                 bbmin = cg.BBMin;
                 bbmax = cg.BBMax;
                 float arrowlen = cg._CCarGen.perpendicularLength;
                 float arrowrad = arrowlen * 0.066f;
-                Renderer.RenderSelectionArrowOutline(cg.Position, Vector3.UnitX, Vector3.UnitY, ori, arrowlen, arrowrad, cgrn);
+                Renderer.RenderSelectionArrowOutline(cg.Position, Vector3.UnitX, Vector3.UnitY, cg.Orientation, arrowlen, arrowrad, cgrn);
 
-                Quaternion cgtrn = Quaternion.RotationAxis(Vector3.UnitZ, (float)Math.PI * -0.5f); //car fragments currently need to be rotated 90 deg right...
-                Quaternion cgori = Quaternion.Multiply(ori, cgtrn);
-
-                Renderer.RenderCar(cg.Position, cgori, cg._CCarGen.carModel, cg._CCarGen.popGroup);
+                Renderer.RenderCar(cg);
             }
             if (selectionItem.PathNode != null)
             {
@@ -1377,7 +1373,7 @@ namespace CodeWalker
                     Vector3 dup = Vector3.UnitZ;
                     var aori = Quaternion.Invert(Quaternion.RotationLookAtRH(dir, dup));
                     float arrowrad = 0.25f;
-                    float arrowlen = Math.Max(dl - arrowrad*5.0f, 0);
+                    float arrowlen = Math.Max(dl - arrowrad * 5.0f, 0);
                     Renderer.RenderSelectionArrowOutline(sn1.Position, -Vector3.UnitZ, Vector3.UnitY, aori, arrowlen, arrowrad, cblu);
                 }
             }
@@ -1407,7 +1403,7 @@ namespace CodeWalker
                             }
                             for (int ic = 0; ic < portal.Corners.Length; ic++)
                             {
-                                int il = ((ic==0)? portal.Corners.Length : ic) - 1;
+                                int il = ((ic == 0) ? portal.Corners.Length : ic) - 1;
                                 p1.Position = mlop + mlo.Orientation.Multiply(portal.Corners[il].XYZ());
                                 p2.Position = mlop + mlo.Orientation.Multiply(portal.Corners[ic].XYZ());
                                 Renderer.SelectionLineVerts.Add(p1);
@@ -1656,7 +1652,7 @@ namespace CodeWalker
             }
             else
             {
-                SelectedItem.SetPosition(newpos, EditEntityPivot);                
+                SelectedItem.SetPosition(newpos, EditEntityPivot);
             }
             if (ProjectForm != null)
             {
@@ -2166,7 +2162,7 @@ namespace CodeWalker
 
 
         }
-        
+
         public SpaceRayIntersectResult GetSpaceMouseRay()
         {
             SpaceRayIntersectResult ret = new SpaceRayIntersectResult();
@@ -2201,7 +2197,7 @@ namespace CodeWalker
             //if ((SelectionMode == MapSelectionMode.Entity) && !MouseSelectEnabled) return; //performance improvement when not selecting entities...
 
             //test the selected entity/archetype for mouse hit.
-            
+
             //first test the bounding sphere for mouse hit..
             Quaternion orinv;
             Ray mraytrn;
@@ -2244,7 +2240,7 @@ namespace CodeWalker
                 //transform the mouse ray into the entity space.
                 orinv = Quaternion.Invert(orientation);
                 mraytrn = new Ray();
-                mraytrn.Position = orinv.Multiply(camera.MouseRay.Position-camrel);
+                mraytrn.Position = orinv.Multiply(camera.MouseRay.Position - camrel);
                 mraytrn.Direction = orinv.Multiply(camera.MouseRay.Direction);
 
                 if (SelectionMode == MapSelectionMode.EntityExtension)
@@ -2318,7 +2314,7 @@ namespace CodeWalker
 
             bool usegeomboxes = SelectByGeometry;
             var dmodels = drawable.DrawableModelsHigh;
-            if((dmodels==null)||(dmodels.data_items==null))
+            if ((dmodels == null) || (dmodels.data_items == null))
             { usegeomboxes = false; }
             if (usegeomboxes)
             {
@@ -2335,7 +2331,7 @@ namespace CodeWalker
             //transform the mouse ray into the entity space.
             orinv = Quaternion.Invert(orientation);
             mraytrn = new Ray();
-            mraytrn.Position = orinv.Multiply(camera.MouseRay.Position-camrel);
+            mraytrn.Position = orinv.Multiply(camera.MouseRay.Position - camrel);
             mraytrn.Direction = orinv.Multiply(camera.MouseRay.Direction);
             hitdist = 0.0f;
 
@@ -2372,7 +2368,7 @@ namespace CodeWalker
                                     float r2 = b2.Length() * 0.5f;
                                     radsm = (r1 < (r2));// * 0.5f));
                                 }
-                                if ((nearer&&radsm) || radsm) usehit = true;
+                                if ((nearer && radsm) || radsm) usehit = true;
                             }
                         }
                         else if (j == 0) //no hit on model box
@@ -2414,7 +2410,7 @@ namespace CodeWalker
                             float r2 = CurMouseHit.Archetype.BSRadius;
                             radsm = (r1 <= (r2));// * 0.5f)); //prefer selecting smaller things
                         }
-                        if ((nearer&&radsm) || radsm)
+                        if ((nearer && radsm) || radsm)
                         {
                             outerhit = true;
                         }
@@ -3263,7 +3259,7 @@ namespace CodeWalker
             bool change = false;
             if (mhit != null)
             {
-                change = SelectedItem.CheckForChanges(mhitv); 
+                change = SelectedItem.CheckForChanges(mhitv);
             }
             else
             {
@@ -3965,7 +3961,7 @@ namespace CodeWalker
                         }
                         tgnode.Expand();
                     }
-                    
+
                 }
 
                 mnode.Expand();
@@ -4156,7 +4152,8 @@ namespace CodeWalker
                         LoadWorld();
                     }
                 }
-                Invoke(new Action(()=> {
+                Invoke(new Action(() =>
+                {
                     Cursor = Cursors.Default;
                 }));
             });
@@ -4177,7 +4174,8 @@ namespace CodeWalker
                         LoadWorld();
                     }
                 }
-                Invoke(new Action(() => {
+                Invoke(new Action(() =>
+                {
                     Cursor = Cursors.Default;
                 }));
             });
@@ -7204,7 +7202,7 @@ namespace CodeWalker
                 MessageBox.Show("Please close the Project Window before enabling or disabling mods.");
                 return;
             }
-            
+
             SetModsEnabled(EnableModsCheckBox.Checked);
         }
 
@@ -7799,6 +7797,11 @@ namespace CodeWalker
         {
             var statsForm = new StatisticsForm(this);
             statsForm.Show(this);
+        }
+
+        private void ShowVehicleModels_CheckedChanged(object sender, EventArgs e)
+        {
+            Renderer.renderCars = ShowVehicleModelsCheckBox.Checked;
         }
     }
 

--- a/WorldForm.cs
+++ b/WorldForm.cs
@@ -7803,6 +7803,12 @@ namespace CodeWalker
         {
             Renderer.renderCars = ShowVehicleModelsCheckBox.Checked;
         }
+
+
+        private void checkBox1_CheckedChanged(object sender, EventArgs e)
+        {
+            Renderer.renderCustomCars = ShowCustomVehicleModelsCheckBox.Checked;
+        }
     }
 
     public enum WorldControlMode

--- a/WorldForm.resx
+++ b/WorldForm.resx
@@ -250,6 +250,25 @@ ufo
         wGPC48uu7w5IGd+gBlpRMgYCnRwyESUj3CsQkYNFDwAAAABJRU5ErkJggg==
 </value>
   </data>
+  <data name="ToolbarObjectSpaceButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wgAADsIBFShKgAAAAHRJREFUOE/tk0EKgCAQRedIncGrGZ602lowuFW/kM1ElLYLEh668D1dKO2DmYcQ
+        gs/EHpTsnIvGmGZKQMrWjnH12y3ztJR9NfBGxiwD6lpPQEYMaxU4n3aF3PcHPh/AY8Ljy67vDkgZ36AG
+        WlEyBgKdHDIRJSPcKxCRg0UPAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="ToolbarWorldSpaceButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wwAADsMBx2+oZAAAAThJREFUOE+dk01ugzAQhTlBj+MDIJC4A1yEa7DMnlWaSiAu0ZI7BNi0XaRpF7Bg
+        4/pzbMsQ0qod6SX2zHvPP4yDdUzTJBR2CieF2YAxOWFot6GKDwrlMAyyKAqZZZkMw1AjTVOdowYHrpFd
+        w4if67p2os/L1wI2DwfuwkRNSitu2+NdA1szJqUVC7ZGYb9/dOQtA/6bptFjcxyBwY7zkfwL0KDF4ESC
+        7bHCx/miCf7qYJ1jjjYYx3Fm0nfDXfJWzhjMzuBweJJvr++b5K1dOQN7hP9AH0H96EvM83zh7q+2zsH1
+        L1H0fS+TJHEX+ZsBXDRobS/oRorjWB5/aqSXVkZRJKuqQnxtJEJNXCvjTu9D9kGOmhEvW5kwJiVb43wI
+        WBXYx9R1nV75RuyHKrrnzCcGjE1u9ZyD4BugoZigQ9xrngAAAABJRU5ErkJggg==
+</value>
+  </data>
   <data name="ToolbarSnapButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
@@ -257,6 +276,34 @@ ufo
         ZI2JiU7VVIVlp7OL+1mllIr7cb8Ie++PQwQYITnnM24NWxoBgsQYm/l+gk699bMsRA4h1JTSPsg0Xert
         em/mGwh3vW1Z7MvIABSWqXG3+iZHAEw1m4wD49oVANgVOL/VeSgeDAiX1mpWeKy9BIQiI+OxWQF77tG5
         2Fc729BmeElf/3lNhORe+oecewDObEqX49RqCgAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="ToolbarSnapToGroundButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
+        dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADMSURBVDhPrZLBDcMgDEUzGxN0ilyZJ92DqXJoe4Cr
+        y3f8EXERUptaehVx/F8gzSIil1hKKWIMB8C0EA4hTCXToqCXVFbjOwElKSUF65zzzUbHhad4CYkxyr7v
+        KvHHIhQ0ybbd5fl4KVhDgns+SPSnDqzYMgQME/TsOO2d/EVQ17ozXmgD2/VHgMCGdY5h9psALwovDBLc
+        9GAYcwyzZ//FUZCgiS3btj8k/tqiR3Xn0w+pDp2e2IN+xZJWncAzDINTTQSAwRYGLfQbsrwBmeh5Q8G/
+        p8gAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="ToolbarSnapToGridButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wgAADsIBFShKgAAAAH5JREFUOE+9kEEKwCAMBH2bL+hPfI/9ooe2B71aVpKS5iBB0i4MyCZZjcFdrbUu
+        IdsuDMUYB/8H1Fo3HQCPynOhsZTSU0pPAM7wpiG4hcFAzns/j2uAMzzZo3ntDHiYkTWNXwCztAJr+ROl
+        0IhU+UTzMEsHkG2XS4CE7K8Uwg0o2F4o9CrlEwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="ToolbarSnapToGroundGridButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
+        dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADLSURBVDhPpZHRDcIwDEQzWxbqGEjZoOzRqfoBfLS/
+        Jnf1IWMKAmrpSYl7d3HSYmaHKOu6msNG2BOKPhVEtdZHiPbqfR0QQqy1Rn4OUMg0TQTrZVlOLt2vLnoJ
+        EcMw2DzPDMEke9AsYBrHs10vN4I1QqImwwDcFyMjQGaBHr5Bo8nEoYCnCQTGzVeI4oj6fIi+KHgoPBhC
+        4knCjTww9vxfbIUQNDEyiGIZ8t6tW/k0vC/AOpuiueNOLwVkUeylvju9FJCg8E1vM/2PlTv5UoervVTJ
+        uQAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="ToolbarUndoButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -353,53 +400,6 @@ ufo
         UIVMtMHfWUUj4nIg/KurGIYrSAZYOXDGlbhXcZlegUO8Yxzb+BlQAwNW0G0jVAYK0AwHtnCEOyQDZvGC
         ObTbKIIvLMA9WIYDizhFMsDjfsAZptCA9JcdfoVBvryOSbgCe4HPTuCz+BQMKEUvJmCy96ET1ehCuAf2
         5ZF+uwdZKEYtmuBGFSIXhtejBe5PHX7dxL+qKPoEppRHcXOtiDsAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="ToolbarObjectSpaceButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAHRJREFUOE/tk0EKgCAQRedIncGrGZ602lowuFW/kM1ElLYLEh668D1dKO2DmYcQ
-        gs/EHpTsnIvGmGZKQMrWjnH12y3ztJR9NfBGxiwD6lpPQEYMaxU4n3aF3PcHPh/AY8Ljy67vDkgZ36AG
-        WlEyBgKdHDIRJSPcKxCRg0UPAAAAAElFTkSuQmCC
-</value>
-  </data>
-  <data name="ToolbarWorldSpaceButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        xAAADsQBlSsOGwAAAThJREFUOE+dk01ugzAQhTlBj+MDIJC4A1yEa7DMnlWaSiAu0ZI7BNi0XaRpF7Bg
-        4/pzbMsQ0qod6SX2zHvPP4yDdUzTJBR2CieF2YAxOWFot6GKDwrlMAyyKAqZZZkMw1AjTVOdowYHrpFd
-        w4if67p2os/L1wI2DwfuwkRNSitu2+NdA1szJqUVC7ZGYb9/dOQtA/6bptFjcxyBwY7zkfwL0KDF4ESC
-        7bHCx/miCf7qYJ1jjjYYx3Fm0nfDXfJWzhjMzuBweJJvr++b5K1dOQN7hP9AH0H96EvM83zh7q+2zsH1
-        L1H0fS+TJHEX+ZsBXDRobS/oRorjWB5/aqSXVkZRJKuqQnxtJEJNXCvjTu9D9kGOmhEvW5kwJiVb43wI
-        WBXYx9R1nV75RuyHKrrnzCcGjE1u9ZyD4BugoZigQ9xrngAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="ToolbarSnapToGroundButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
-        dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADMSURBVDhPrZLBDcMgDEUzGxN0ilyZJ92DqXJoe4Cr
-        y3f8EXERUptaehVx/F8gzSIil1hKKWIMB8C0EA4hTCXToqCXVFbjOwElKSUF65zzzUbHhad4CYkxyr7v
-        KvHHIhQ0ybbd5fl4KVhDgns+SPSnDqzYMgQME/TsOO2d/EVQ17ozXmgD2/VHgMCGdY5h9psALwovDBLc
-        9GAYcwyzZ//FUZCgiS3btj8k/tqiR3Xn0w+pDp2e2IN+xZJWncAzDINTTQSAwRYGLfQbsrwBmeh5Q8G/
-        p8gAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="ToolbarSnapToGridButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAH5JREFUOE+9kEEKwCAMBH2bL+hPfI/9ooe2B71aVpKS5iBB0i4MyCZZjcFdrbUu
-        IdsuDMUYB/8H1Fo3HQCPynOhsZTSU0pPAM7wpiG4hcFAzns/j2uAMzzZo3ntDHiYkTWNXwCztAJr+ROl
-        0IhU+UTzMEsHkG2XS4CE7K8Uwg0o2F4o9CrlEwAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="ToolbarSnapToGroundGridButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
-        dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADLSURBVDhPpZHRDcIwDEQzWxbqGEjZoOzRqfoBfLS/
-        Jnf1IWMKAmrpSYl7d3HSYmaHKOu6msNG2BOKPhVEtdZHiPbqfR0QQqy1Rn4OUMg0TQTrZVlOLt2vLnoJ
-        EcMw2DzPDMEke9AsYBrHs10vN4I1QqImwwDcFyMjQGaBHr5Bo8nEoYCnCQTGzVeI4oj6fIi+KHgoPBhC
-        4knCjTww9vxfbIUQNDEyiGIZ8t6tW/k0vC/AOpuiueNOLwVkUeylvju9FJCg8E1vM/2PlTv5UoervVTJ
-        uQAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="ToolbarCameraPerspectiveButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/WorldForm.resx
+++ b/WorldForm.resx
@@ -242,18 +242,10 @@ ufo
         gd6TMnIikDJyIqjVNz8T7FgKrAwFX6lVinM3aJ05lWDPRRcAAAAASUVORK5CYII=
 </value>
   </data>
-  <data name="ToolbarTransformSpaceButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAB0SURBVDhP7ZNBCoAgEEXnSJ3BqxmetNpaMLhVv5DNRJS2
-        CxIeuvA9XSjtg5mHEILPxB6U7JyLxphmSkDK1o5x9dst87SUfTXwRsYsA+paT0BGDGsVOJ92hdz3Bz4f
-        wGPC48uu7w5IGd+gBlpRMgYCnRwyESUj3CsQkYNFDwAAAABJRU5ErkJggg==
-</value>
-  </data>
   <data name="ToolbarObjectSpaceButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAAHRJREFUOE/tk0EKgCAQRedIncGrGZ602lowuFW/kM1ElLYLEh668D1dKO2DmYcQ
+        wQAADsEBuJFr7QAAAHRJREFUOE/tk0EKgCAQRedIncGrGZ602lowuFW/kM1ElLYLEh668D1dKO2DmYcQ
         gs/EHpTsnIvGmGZKQMrWjnH12y3ztJR9NfBGxiwD6lpPQEYMaxU4n3aF3PcHPh/AY8Ljy67vDkgZ36AG
         WlEyBgKdHDIRJSPcKxCRg0UPAAAAAElFTkSuQmCC
 </value>
@@ -261,7 +253,7 @@ ufo
   <data name="ToolbarWorldSpaceButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAThJREFUOE+dk01ugzAQhTlBj+MDIJC4A1yEa7DMnlWaSiAu0ZI7BNi0XaRpF7Bg
+        wgAADsIBFShKgAAAAThJREFUOE+dk01ugzAQhTlBj+MDIJC4A1yEa7DMnlWaSiAu0ZI7BNi0XaRpF7Bg
         4/pzbMsQ0qod6SX2zHvPP4yDdUzTJBR2CieF2YAxOWFot6GKDwrlMAyyKAqZZZkMw1AjTVOdowYHrpFd
         w4if67p2os/L1wI2DwfuwkRNSitu2+NdA1szJqUVC7ZGYb9/dOQtA/6bptFjcxyBwY7zkfwL0KDF4ESC
         7bHCx/miCf7qYJ1jjjYYx3Fm0nfDXfJWzhjMzuBweJJvr++b5K1dOQN7hP9AH0H96EvM83zh7q+2zsH1
@@ -269,13 +261,12 @@ ufo
         WBXYx9R1nV75RuyHKrrnzCcGjE1u9ZyD4BugoZigQ9xrngAAAABJRU5ErkJggg==
 </value>
   </data>
-  <data name="ToolbarSnapButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="ToolbarTransformSpaceButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACtSURBVDhPrZBBEsIgEAR5Gy/wFV55T/wHr+KgHuCKNsVY
-        ZI2JiU7VVIVlp7OL+1mllIr7cb8Ie++PQwQYITnnM24NWxoBgsQYm/l+gk699bMsRA4h1JTSPsg0Xert
-        em/mGwh3vW1Z7MvIABSWqXG3+iZHAEw1m4wD49oVANgVOL/VeSgeDAiX1mpWeKy9BIQiI+OxWQF77tG5
-        2Fc729BmeElf/3lNhORe+oecewDObEqX49RqCgAAAABJRU5ErkJggg==
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAB0SURBVDhP7ZNBCoAgEEXnSJ3BqxmetNpaMLhVv5DNRJS2
+        CxIeuvA9XSjtg5mHEILPxB6U7JyLxphmSkDK1o5x9dst87SUfTXwRsYsA+paT0BGDGsVOJ92hdz3Bz4f
+        wGPC48uu7w5IGd+gBlpRMgYCnRwyESUj3CsQkYNFDwAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="ToolbarSnapToGroundButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -291,7 +282,7 @@ ufo
   <data name="ToolbarSnapToGridButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAAH5JREFUOE+9kEEKwCAMBH2bL+hPfI/9ooe2B71aVpKS5iBB0i4MyCZZjcFdrbUu
+        wQAADsEBuJFr7QAAAH5JREFUOE+9kEEKwCAMBH2bL+hPfI/9ooe2B71aVpKS5iBB0i4MyCZZjcFdrbUu
         IdsuDMUYB/8H1Fo3HQCPynOhsZTSU0pPAM7wpiG4hcFAzns/j2uAMzzZo3ntDHiYkTWNXwCztAJr+ROl
         0IhU+UTzMEsHkG2XS4CE7K8Uwg0o2F4o9CrlEwAAAABJRU5ErkJggg==
 </value>
@@ -304,6 +295,15 @@ ufo
         EcMw2DzPDMEke9AsYBrHs10vN4I1QqImwwDcFyMjQGaBHr5Bo8nEoYCnCQTGzVeI4oj6fIi+KHgoPBhC
         4knCjTww9vxfbIUQNDEyiGIZ8t6tW/k0vC/AOpuiueNOLwVkUeylvju9FJCg8E1vM/2PlTv5UoervVTJ
         uQAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="ToolbarSnapButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACtSURBVDhPrZBBEsIgEAR5Gy/wFV55T/wHr+KgHuCKNsVY
+        ZI2JiU7VVIVlp7OL+1mllIr7cb8Ie++PQwQYITnnM24NWxoBgsQYm/l+gk699bMsRA4h1JTSPsg0Xert
+        em/mGwh3vW1Z7MvIABSWqXG3+iZHAEw1m4wD49oVANgVOL/VeSgeDAiX1mpWeKy9BIQiI+OxWQF77tG5
+        2Fc729BmeElf/3lNhORe+oecewDObEqX49RqCgAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="ToolbarUndoButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -391,17 +391,6 @@ ufo
         RK5CYII=
 </value>
   </data>
-  <data name="ToolbarCameraModeButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEvSURBVDhP3dK/K0dRGMfxKxRJopCSEkLya/guUhQRmQwG
-        WfwIkYySgYUSKUKJlOK/MBoMFMofYLUIsfJ+f3NuF3+A8tRree5zP/fcc070f6oHT/jAPTqQj6WvXvCM
-        TZQgG3H58gFGcYVLtGIN15jBNDbwiGNUIg4pQx8GsQuHhrCDW8yjHyns4Q0DcCXpykM5bFzgHGPYxw1G
-        UIVMtMHfWUUj4nIg/KurGIYrSAZYOXDGlbhXcZlegUO8Yxzb+BlQAwNW0G0jVAYK0AwHtnCEOyQDZvGC
-        ObTbKIIvLMA9WIYDizhFMsDjfsAZptCA9JcdfoVBvryOSbgCe4HPTuCz+BQMKEUvJmCy96ET1ehCuAf2
-        5ZF+uwdZKEYtmuBGFSIXhtejBe5PHX7dxL+qKPoEppRHcXOtiDsAAAAASUVORK5CYII=
-</value>
-  </data>
   <data name="ToolbarCameraPerspectiveButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
@@ -435,6 +424,17 @@ ufo
         rp3fhGJScIRLzKMLFTC9cMIu3nCDVUyjB6WkYA93mEWbAyH9cMImPuA+rWMA31YwBU82kF6BS32Er/aO
         M8zAh+OEghpcwQ2bg3uwBW8ewFd7xQkm0IA4oaAS7bh2KHjBIZbhV/D6GJkFphrdcIP8lFrAGPwPOjCO
         QdQiTqrAWNICd7gPnUj+xBKaU9dxfhTkjwV/FxU+AbsiGnc46OYIAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="ToolbarCameraModeButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEvSURBVDhP3dK/K0dRGMfxKxRJopCSEkLya/guUhQRmQwG
+        WfwIkYySgYUSKUKJlOK/MBoMFMofYLUIsfJ+f3NuF3+A8tRree5zP/fcc070f6oHT/jAPTqQj6WvXvCM
+        TZQgG3H58gFGcYVLtGIN15jBNDbwiGNUIg4pQx8GsQuHhrCDW8yjHyns4Q0DcCXpykM5bFzgHGPYxw1G
+        UIVMtMHfWUUj4nIg/KurGIYrSAZYOXDGlbhXcZlegUO8Yxzb+BlQAwNW0G0jVAYK0AwHtnCEOyQDZvGC
+        ObTbKIIvLMA9WIYDizhFMsDjfsAZptCA9JcdfoVBvryOSbgCe4HPTuCz+BQMKEUvJmCy96ET1ehCuAf2
+        5ZF+uwdZKEYtmuBGFSIXhtejBe5PHX7dxL+qKPoEppRHcXOtiDsAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">


### PR DESCRIPTION
my visual studio is automatically fixing some style typos and unused usings. why not?
![image](https://user-images.githubusercontent.com/17229619/50339378-3dd2a300-0539-11e9-8b77-936990283794.png)
