### PR TITLE
Added vertex shader PNCTT and started implementation of DiffuseSampler2.

### DIFF
--- a/Rendering/Shaders/BasicShader.cs
+++ b/Rendering/Shaders/BasicShader.cs
@@ -883,6 +883,7 @@ namespace CodeWalker.Rendering
             context.PixelShader.SetShaderResource(2, null);
             context.PixelShader.SetShaderResource(3, null);
             context.PixelShader.SetShaderResource(4, null);
+            context.PixelShader.SetShaderResource(5, null);
             context.VertexShader.SetShaderResource(0, null);
             context.VertexShader.SetShaderResource(1, null);
             context.VertexShader.SetShaderResource(2, null);
@@ -921,6 +922,7 @@ namespace CodeWalker.Rendering
 
             basicps.Dispose();
             basicvspnct.Dispose();
+            basicvspnctt.Dispose();
             basicvspncct.Dispose();
             basicvspncctt.Dispose();
             basicvspnccttt.Dispose();

--- a/Shaders/BasicPS.hlsl
+++ b/Shaders/BasicPS.hlsl
@@ -4,6 +4,7 @@ Texture2D<float4> Colourmap : register(t0);
 Texture2D<float4> Bumpmap : register(t2);
 Texture2D<float4> Specmap : register(t3);
 Texture2D<float4> Detailmap : register(t4);
+Texture2D<float4> Colourmap2 : register(t5);
 SamplerState TextureSS : register(s0);
 
 
@@ -18,6 +19,10 @@ cbuffer PSSceneVars : register(b0)
 cbuffer PSGeomVars : register(b2)
 {
     uint EnableTexture;
+    uint EnableTexture2;
+    uint pad1;
+    uint pad2;
+    uint pad3;
     uint EnableTint;
     uint EnableNormalMap;
     uint EnableSpecMap;
@@ -73,6 +78,12 @@ float4 main(VS_OUTPUT input) : SV_TARGET
         }
 
         c = Colourmap.Sample(TextureSS, texc);
+
+        if (EnableTexture2 == 1)
+        {
+            float4 c2 = Colourmap2.Sample(TextureSS, input.Texcoord1);
+            c = c2.a * c2 + (1 - c2.a) * c;
+        }
 
         if (IsDistMap) c = float4(c.rgb*2, (c.r+c.g+c.b) - 1);
         if ((IsDecal == 0) && (c.a <= 0.33)) discard;

--- a/Shaders/BasicVS_PNCTT.hlsl
+++ b/Shaders/BasicVS_PNCTT.hlsl
@@ -1,0 +1,40 @@
+#include "BasicVS.hlsli"
+
+struct VS_INPUT
+{
+    float4 Position  : POSITION;
+    float3 Normal    : NORMAL;
+    float2 Texcoord0 : TEXCOORD0;
+    float2 Texcoord1 : TEXCOORD1;
+    float4 Colour0   : COLOR0;
+};
+
+
+VS_OUTPUT main(VS_INPUT input, uint iid : SV_InstanceID)
+{
+    VS_OUTPUT output;
+    float3 opos = ModelTransform(input.Position.xyz, input.Colour0.xyz, input.Colour0.xyz, iid);
+    float4 cpos = ScreenTransform(opos);
+    float3 bnorm = NormalTransform(input.Normal);
+    float3 btang = 0.5;// NormalTransform(float3(1, 0, 0)); //no tangent to use on this vertex type...
+    
+    float4 tnt = ColourTint(input.Colour0.b, 0, iid); //colour tinting if enabled
+
+    float4 lightspacepos;
+    float shadowdepth = ShadowmapSceneDepth(opos, lightspacepos);
+    output.LightShadow = lightspacepos;
+    output.Shadows = float4(shadowdepth, 0, 0, 0);
+
+    output.Position = cpos;
+    output.CamRelPos = opos;
+    output.Normal = bnorm;
+    output.Texcoord0 = input.Texcoord0;
+    output.Texcoord1 = input.Texcoord1;
+    output.Texcoord2 = 0.5;// input.Texcoord;
+    output.Colour0 = input.Colour0;
+    output.Colour1 = float4(0.5, 0.5, 0.5, 1); //input.Colour;
+    output.Tint = tnt;
+    output.Tangent = float4(btang, 1);
+    output.Bitangent = float4(cross(btang, bnorm), 0);
+    return output;
+}

--- a/Shaders/CodeWalkerShaders.vcxproj
+++ b/Shaders/CodeWalkerShaders.vcxproj
@@ -196,6 +196,16 @@
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4.0</ShaderModel>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4.0</ShaderModel>
     </FxCompile>
+    <FxCompile Include="BasicVS_PNCTT.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4.0</ShaderModel>
+    </FxCompile>
     <FxCompile Include="BasicVS_PNCTTTX.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Vertex</ShaderType>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>

--- a/Shaders/CodeWalkerShaders.vcxproj.filters
+++ b/Shaders/CodeWalkerShaders.vcxproj.filters
@@ -22,6 +22,7 @@
     <FxCompile Include="ShadowVS.hlsl" />
     <FxCompile Include="ShadowPS.hlsl" />
     <FxCompile Include="BasicVS_PNCT.hlsl" />
+    <FxCompile Include="BasicVS_PNCTT.hlsl" />
     <FxCompile Include="BasicVS_PNCTX.hlsl" />
     <FxCompile Include="BasicVS_PNCCT.hlsl" />
     <FxCompile Include="BasicVS_PNCCTT.hlsl" />


### PR DESCRIPTION
This mainly enables CodeWalker to render additional textures for vehicles.
The vertex shader is pretty much copy&pasted.

Issues:
- weird rotor blades on top of helis
- needs handling of multiple textures for the same coordinates
- maybe there is a smart alternative for the padding in the shader buffer?