### PR TITLE
Convert Folder Selector dialog to new user-friendly version

### DIFF
--- a/CodeWalker.csproj
+++ b/CodeWalker.csproj
@@ -94,6 +94,12 @@
     <Reference Include="FastColoredTextBox, Version=2.16.24.0, Culture=neutral, PublicKeyToken=fb8aa12b994ef61b, processorArchitecture=MSIL">
       <HintPath>packages\FCTB.2.16.24\lib\FastColoredTextBox.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.WindowsAPICodePack, Version=1.1.3.3, Culture=neutral, PublicKeyToken=8985beaab7ea3f04, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft-WindowsAPICodePack-Core.1.1.3.3\lib\net452\Microsoft.WindowsAPICodePack.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAPICodePack.Shell, Version=1.1.3.3, Culture=neutral, PublicKeyToken=8985beaab7ea3f04, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft-WindowsAPICodePack-Shell.1.1.3.3\lib\net452\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
+    </Reference>
     <Reference Include="SharpDX, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <HintPath>packages\SharpDX.4.0.1\lib\net45\SharpDX.dll</HintPath>
     </Reference>

--- a/ExploreForm.Designer.cs
+++ b/ExploreForm.Designer.cs
@@ -142,7 +142,6 @@
             this.TreeContextCollapseAllMenu = new System.Windows.Forms.ToolStripMenuItem();
             this.SaveFileDialog = new System.Windows.Forms.SaveFileDialog();
             this.OpenFileDialog = new System.Windows.Forms.OpenFileDialog();
-            this.FolderBrowserDialog = new System.Windows.Forms.FolderBrowserDialog();
             this.VSExtender = new WeifenLuo.WinFormsUI.Docking.VisualStudioToolStripExtender(this.components);
             this.MainMenu.SuspendLayout();
             this.MainToolbar.SuspendLayout();
@@ -1291,7 +1290,6 @@
         private System.Windows.Forms.ToolStripMenuItem TreeContextCollapseAllMenu;
         private System.Windows.Forms.SaveFileDialog SaveFileDialog;
         private System.Windows.Forms.OpenFileDialog OpenFileDialog;
-        private System.Windows.Forms.FolderBrowserDialog FolderBrowserDialog;
         private System.Windows.Forms.ToolStripMenuItem FileExitMenu;
         private System.Windows.Forms.ToolStripMenuItem EditViewMenu;
         private System.Windows.Forms.ToolStripMenuItem EditViewHexMenu;

--- a/ExploreForm.cs
+++ b/ExploreForm.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Xml;
 using WeifenLuo.WinFormsUI.Docking;
+using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace CodeWalker
 {
@@ -48,6 +49,7 @@ namespace CodeWalker
 
         public ThemeBase Theme { get; private set; }
 
+        public CommonOpenFileDialog FolderBrowserDialog = new CommonOpenFileDialog("Select a Folder") { IsFolderPicker = true, Multiselect = false, EnsurePathExists = true };
 
         public ExploreForm()
         {
@@ -1915,8 +1917,8 @@ namespace CodeWalker
             }
             else
             {
-                if (FolderBrowserDialog.ShowDialog() != DialogResult.OK) return;
-                string folderpath = FolderBrowserDialog.SelectedPath;
+                if (FolderBrowserDialog.ShowDialog() != CommonFileDialogResult.Ok) return;
+                string folderpath = FolderBrowserDialog.FileName;
                 if (!folderpath.EndsWith("\\")) folderpath += "\\";
 
                 StringBuilder errors = new StringBuilder();
@@ -1998,8 +2000,8 @@ namespace CodeWalker
             }
             else
             {
-                if (FolderBrowserDialog.ShowDialog() != DialogResult.OK) return;
-                string folderpath = FolderBrowserDialog.SelectedPath;
+                if (FolderBrowserDialog.ShowDialog() != CommonFileDialogResult.Ok) return;
+                string folderpath = FolderBrowserDialog.FileName;
                 if (!folderpath.EndsWith("\\")) folderpath += "\\";
 
                 StringBuilder errors = new StringBuilder();
@@ -2070,8 +2072,8 @@ namespace CodeWalker
             }
             else
             {
-                if (FolderBrowserDialog.ShowDialog() != DialogResult.OK) return;
-                string folderpath = FolderBrowserDialog.SelectedPath;
+                if (FolderBrowserDialog.ShowDialog() != CommonFileDialogResult.Ok) return;
+                string folderpath = FolderBrowserDialog.FileName;
                 if (!folderpath.EndsWith("\\")) folderpath += "\\";
 
                 StringBuilder errors = new StringBuilder();
@@ -2111,8 +2113,8 @@ namespace CodeWalker
         private void ExtractAll()
         {
             if (CurrentFiles == null) return;
-            if (FolderBrowserDialog.ShowDialog() != DialogResult.OK) return;
-            string folderpath = FolderBrowserDialog.SelectedPath;
+            if (FolderBrowserDialog.ShowDialog() != CommonFileDialogResult.Ok) return;
+            string folderpath = FolderBrowserDialog.FileName;
             if (!folderpath.EndsWith("\\")) folderpath += "\\";
 
             StringBuilder errors = new StringBuilder();

--- a/ExploreForm.resx
+++ b/ExploreForm.resx
@@ -313,7 +313,7 @@
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
         ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAADo
-        HwAAAk1TRnQBSQFMAgEBGAEAATgBAQE4AQEBEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        HwAAAk1TRnQBSQFMAgEBGAEAAVABAQFQAQEBEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
         AwABQAMAAXADAAEBAQABCAYAARwYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
         AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
         AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
@@ -588,9 +588,6 @@
   </metadata>
   <metadata name="OpenFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 56</value>
-  </metadata>
-  <metadata name="FolderBrowserDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>152, 56</value>
   </metadata>
   <metadata name="VSExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>317, 56</value>

--- a/SelectFolderForm.Designer.cs
+++ b/SelectFolderForm.Designer.cs
@@ -33,7 +33,6 @@
             this.label1 = new System.Windows.Forms.Label();
             this.FolderBrowseButton = new System.Windows.Forms.Button();
             this.FolderTextBox = new System.Windows.Forms.TextBox();
-            this.FolderBrowserDialog = new System.Windows.Forms.FolderBrowserDialog();
             this.CancelButt = new System.Windows.Forms.Button();
             this.RememberFolderCheckbox = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
@@ -133,7 +132,6 @@
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Button FolderBrowseButton;
         private System.Windows.Forms.TextBox FolderTextBox;
-        private System.Windows.Forms.FolderBrowserDialog FolderBrowserDialog;
         private System.Windows.Forms.Button CancelButt;
         private System.Windows.Forms.CheckBox RememberFolderCheckbox;
     }

--- a/SelectFolderForm.cs
+++ b/SelectFolderForm.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace CodeWalker
 {
@@ -31,11 +32,11 @@ namespace CodeWalker
 
         private void FolderBrowseButton_Click(object sender, EventArgs e)
         {
-            FolderBrowserDialog.SelectedPath = FolderTextBox.Text;
-            DialogResult res = FolderBrowserDialog.ShowDialog();
-            if (res == DialogResult.OK)
+            CommonOpenFileDialog folderDialog = new CommonOpenFileDialog("Select GTA V Folder") { DefaultDirectory = FolderTextBox.Text, IsFolderPicker = true, AddToMostRecentlyUsedList = true, AllowNonFileSystemItems = false, EnsurePathExists = true, Multiselect = false };
+            CommonFileDialogResult res = folderDialog.ShowDialog();
+            if (res == CommonFileDialogResult.Ok)
             {
-                FolderTextBox.Text = FolderBrowserDialog.SelectedPath;
+                FolderTextBox.Text = folderDialog.FileName;
             }
         }
 

--- a/SelectFolderForm.resx
+++ b/SelectFolderForm.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="FolderBrowserDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/packages.config
+++ b/packages.config
@@ -3,6 +3,8 @@
   <package id="DockPanelSuite" version="3.0.6" targetFramework="net452" />
   <package id="DockPanelSuite.ThemeVS2015" version="3.0.6" targetFramework="net452" />
   <package id="FCTB" version="2.16.24" targetFramework="net452" />
+  <package id="Microsoft-WindowsAPICodePack-Core" version="1.1.3.3" targetFramework="net452" />
+  <package id="Microsoft-WindowsAPICodePack-Shell" version="1.1.3.3" targetFramework="net452" />
   <package id="SharpDX" version="4.0.1" targetFramework="net452" />
   <package id="SharpDX.D3DCompiler" version="4.0.1" targetFramework="net452" />
   <package id="SharpDX.Direct2D1" version="4.0.1" targetFramework="net452" />


### PR DESCRIPTION
Started converting `System.Windows.Forms.FolderBrowserDialog` to the new user-friendly style introduced in Windows 7, which provides a more complete Windows Explorer UI to browse to the desired folder.

## Old
![image](https://user-images.githubusercontent.com/17376331/67660487-2106b900-f91c-11e9-992e-d70020576b75.png)


## New
![image](https://user-images.githubusercontent.com/17376331/67659321-40501700-f919-11e9-831e-773cba013988.png)

Started converting a couple of classes. The old-style dialog is present in a lot of locations in the code, so seeking review before continuing. 

![image](https://user-images.githubusercontent.com/17376331/67659476-a5a40800-f919-11e9-87e3-3612f3e11013.png)
