### PR TITLE
Add a setting to only load mods stuff

### DIFF
--- a/App.config
+++ b/App.config
@@ -202,6 +202,9 @@
             <setting name="ExplorerWindowTheme" serializeAs="String">
                 <value>Windows</value>
             </setting>
+            <setting name="OnlyMods" serializeAs="String">
+                <value>False</value>
+            </setting>
         </CodeWalker.Properties.Settings>
     </userSettings>
   <runtime>

--- a/CodeWalker.Core/GameFiles/GameFileCache.cs
+++ b/CodeWalker.Core/GameFiles/GameFileCache.cs
@@ -93,7 +93,7 @@ namespace CodeWalker.GameFiles
 
         private string GTAFolder;
         private string ExcludeFolders;
-
+        private bool OnlyMods = false;
 
 
         public int QueueLength
@@ -120,7 +120,7 @@ namespace CodeWalker.GameFiles
 
 
 
-        public GameFileCache(long size, double cacheTime, string folder, string dlc, bool mods, string excludeFolders)
+        public GameFileCache(long size, double cacheTime, string folder, string dlc, bool mods, string excludeFolders, bool onlyMods = false)
         {
             mainCache = new Cache<GameFileCacheKey, GameFile>(size, cacheTime);//2GB is good as default
             SelectedDlc = dlc;
@@ -128,6 +128,7 @@ namespace CodeWalker.GameFiles
             EnableMods = mods;
             GTAFolder = folder;
             ExcludeFolders = excludeFolders;
+            OnlyMods = onlyMods;
         }
 
 
@@ -961,6 +962,7 @@ namespace CodeWalker.GameFiles
                         RpfFileEntry fentry = entry as RpfFileEntry;
                         if (entry.NameLower.EndsWith(".ymap"))
                         {
+                            if (OnlyMods && !entry.Path.Contains("mods")) continue;
                             //YmapDict[entry.NameHash] = fentry;
                             YmapDict[entry.ShortNameHash] = fentry;
                         }
@@ -971,6 +973,7 @@ namespace CodeWalker.GameFiles
                         }
                         else if (entry.NameLower.EndsWith(".ynv"))
                         {
+                            if (OnlyMods && !entry.Path.Contains("mods")) continue;
                             YnvDict[entry.ShortNameHash] = fentry;
                         }
                     }
@@ -988,6 +991,7 @@ namespace CodeWalker.GameFiles
                         RpfFileEntry fentry = entry as RpfFileEntry;
                         if (entry.NameLower.EndsWith(".ymap"))
                         {
+                            if (OnlyMods && !entry.Path.Contains("mods")) continue;
                             AllYmapsDict[entry.ShortNameHash] = fentry;
                         }
                     }

--- a/CodeWalker.Core/World/Space.cs
+++ b/CodeWalker.Core/World/Space.cs
@@ -40,13 +40,13 @@ namespace CodeWalker.World
 
         public SpaceNavGrid NavGrid;
 
-        public List<SpaceEntityCollision> Collisions = new List<SpaceEntityCollision>(); 
+        public List<SpaceEntityCollision> Collisions = new List<SpaceEntityCollision>();
 
-
-        public void Init(GameFileCache gameFileCache, Action<string> updateStatus)
+        private bool OnlyMods = false;
+        public void Init(GameFileCache gameFileCache, Action<string> updateStatus, bool onlyMods = false)
         {
             GameFileCache = gameFileCache;
-
+            OnlyMods = onlyMods;
 
             updateStatus("Scanning manifests...");
 
@@ -418,6 +418,7 @@ namespace CodeWalker.World
             Dictionary<uint, RpfFileEntry> yndentries = new Dictionary<uint, RpfFileEntry>();
             foreach (var rpffile in GameFileCache.BaseRpfs) //load nodes from base rpfs
             {
+                if (OnlyMods && !rpffile.FilePath.Contains("mods")) continue;
                 AddRpfYnds(rpffile, yndentries);
             }
             if (GameFileCache.EnableDlc)
@@ -427,6 +428,7 @@ namespace CodeWalker.World
                 {
                     foreach (var rpffile in updrpf.Children)
                     {
+                        if (OnlyMods && !rpffile.FilePath.Contains("mods")) continue;
                         AddRpfYnds(rpffile, yndentries);
                     }
                 }
@@ -435,6 +437,7 @@ namespace CodeWalker.World
                     if (dlcrpf.Path.StartsWith("x64")) continue; //don't override update.rpf YNDs with x64 ones! *hack
                     foreach (var rpffile in dlcrpf.Children)
                     {
+                        if (OnlyMods && !rpffile.FilePath.Contains("mods")) continue;
                         AddRpfYnds(rpffile, yndentries);
                     }
                 }
@@ -723,6 +726,7 @@ namespace CodeWalker.World
             Dictionary<uint, RpfFileEntry> ynventries = new Dictionary<uint, RpfFileEntry>();
             foreach (var rpffile in GameFileCache.BaseRpfs) //load navmeshes from base rpfs
             {
+                if (OnlyMods && !rpffile.FilePath.Contains("mods")) continue;
                 AddRpfYnvs(rpffile, ynventries);
             }
             if (GameFileCache.EnableDlc)
@@ -732,6 +736,7 @@ namespace CodeWalker.World
                 {
                     foreach (var rpffile in updrpf.Children)
                     {
+                        if (OnlyMods && !rpffile.FilePath.Contains("mods")) continue;
                         AddRpfYnvs(rpffile, ynventries);
                     }
                 }
@@ -739,6 +744,7 @@ namespace CodeWalker.World
                 {
                     foreach (var rpffile in dlcrpf.Children)
                     {
+                        if (OnlyMods && !rpffile.FilePath.Contains("mods")) continue;
                         AddRpfYnvs(rpffile, ynventries);
                     }
                 }

--- a/GameFiles/GameFileCacheFactory.cs
+++ b/GameFiles/GameFileCacheFactory.cs
@@ -12,7 +12,7 @@ namespace CodeWalker.GameFiles
         public static GameFileCache Create()
         {
             var s = Settings.Default;
-            return new GameFileCache(s.CacheSize, s.CacheTime, GTAFolder.CurrentGTAFolder, s.DLC, s.EnableMods, s.ExcludeFolders);
+            return new GameFileCache(s.CacheSize, s.CacheTime, GTAFolder.CurrentGTAFolder, s.DLC, s.EnableMods, s.ExcludeFolders, s.OnlyMods);
         }
 
     }

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -734,5 +734,20 @@ namespace CodeWalker.Properties {
                 this["ExplorerWindowTheme"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool OnlyMods
+        {
+            get
+            {
+                return ((bool)(this["OnlyMods"]));
+            }
+            set
+            {
+                this["OnlyMods"] = value;
+            }
+        }
     }
 }

--- a/SettingsForm.Designer.cs
+++ b/SettingsForm.Designer.cs
@@ -47,6 +47,7 @@
             this.KeyBindButton = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
             this.AdvancedTabPage = new System.Windows.Forms.TabPage();
+            this.label24 = new System.Windows.Forms.Label();
             this.label22 = new System.Windows.Forms.Label();
             this.CollisionCacheSizeUpDown = new System.Windows.Forms.NumericUpDown();
             this.label23 = new System.Windows.Forms.Label();
@@ -80,6 +81,7 @@
             this.DoneButton = new System.Windows.Forms.Button();
             this.SaveButton = new System.Windows.Forms.Button();
             this.ResetButton = new System.Windows.Forms.Button();
+            this.checkboxMods = new System.Windows.Forms.CheckBox();
             this.MainTabControl.SuspendLayout();
             this.ControlsTabPage.SuspendLayout();
             this.groupBox2.SuspendLayout();
@@ -296,6 +298,10 @@
             // 
             // AdvancedTabPage
             // 
+            this.AdvancedTabPage.AutoScroll = true;
+            this.AdvancedTabPage.AutoScrollMargin = new System.Drawing.Size(0, 200);
+            this.AdvancedTabPage.Controls.Add(this.checkboxMods);
+            this.AdvancedTabPage.Controls.Add(this.label24);
             this.AdvancedTabPage.Controls.Add(this.label22);
             this.AdvancedTabPage.Controls.Add(this.CollisionCacheSizeUpDown);
             this.AdvancedTabPage.Controls.Add(this.label23);
@@ -326,6 +332,7 @@
             this.AdvancedTabPage.Controls.Add(this.FolderBrowseButton);
             this.AdvancedTabPage.Controls.Add(this.FolderTextBox);
             this.AdvancedTabPage.Controls.Add(this.label5);
+            this.AdvancedTabPage.ImeMode = System.Windows.Forms.ImeMode.On;
             this.AdvancedTabPage.Location = new System.Drawing.Point(4, 22);
             this.AdvancedTabPage.Name = "AdvancedTabPage";
             this.AdvancedTabPage.Padding = new System.Windows.Forms.Padding(3);
@@ -333,6 +340,15 @@
             this.AdvancedTabPage.TabIndex = 1;
             this.AdvancedTabPage.Text = "Advanced";
             this.AdvancedTabPage.UseVisualStyleBackColor = true;
+            // 
+            // label24
+            // 
+            this.label24.AutoSize = true;
+            this.label24.Location = new System.Drawing.Point(6, 364);
+            this.label24.Name = "label24";
+            this.label24.Size = new System.Drawing.Size(56, 13);
+            this.label24.TabIndex = 79;
+            this.label24.Text = "Only mods";
             // 
             // label22
             // 
@@ -584,7 +600,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.ExcludeFoldersTextBox.Location = new System.Drawing.Point(110, 61);
             this.ExcludeFoldersTextBox.Name = "ExcludeFoldersTextBox";
-            this.ExcludeFoldersTextBox.Size = new System.Drawing.Size(303, 20);
+            this.ExcludeFoldersTextBox.Size = new System.Drawing.Size(295, 20);
             this.ExcludeFoldersTextBox.TabIndex = 50;
             this.ExcludeFoldersTextBox.TextChanged += new System.EventHandler(this.ExcludeFoldersTextBox_TextChanged);
             // 
@@ -735,7 +751,7 @@
             // FolderBrowseButton
             // 
             this.FolderBrowseButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.FolderBrowseButton.Location = new System.Drawing.Point(419, 27);
+            this.FolderBrowseButton.Location = new System.Drawing.Point(411, 27);
             this.FolderBrowseButton.Name = "FolderBrowseButton";
             this.FolderBrowseButton.Size = new System.Drawing.Size(27, 23);
             this.FolderBrowseButton.TabIndex = 49;
@@ -750,7 +766,7 @@
             this.FolderTextBox.Location = new System.Drawing.Point(110, 28);
             this.FolderTextBox.Name = "FolderTextBox";
             this.FolderTextBox.ReadOnly = true;
-            this.FolderTextBox.Size = new System.Drawing.Size(303, 20);
+            this.FolderTextBox.Size = new System.Drawing.Size(295, 20);
             this.FolderTextBox.TabIndex = 48;
             // 
             // label5
@@ -794,6 +810,17 @@
             this.ResetButton.Text = "Reset all settings";
             this.ResetButton.UseVisualStyleBackColor = true;
             this.ResetButton.Click += new System.EventHandler(this.ResetButton_Click);
+            // 
+            // checkboxMods
+            // 
+            this.checkboxMods.AutoSize = true;
+            this.checkboxMods.Location = new System.Drawing.Point(110, 364);
+            this.checkboxMods.Name = "checkboxMods";
+            this.checkboxMods.Size = new System.Drawing.Size(281, 17);
+            this.checkboxMods.TabIndex = 80;
+            this.checkboxMods.Text = "Disable ymap/ynd/popzone/navmeshes from other rpf";
+            this.checkboxMods.UseVisualStyleBackColor = true;
+            this.checkboxMods.CheckedChanged += new System.EventHandler(this.checkboxMods_CheckedChanged);
             // 
             // SettingsForm
             // 
@@ -883,5 +910,7 @@
         private System.Windows.Forms.NumericUpDown TextureCacheSizeUpDown;
         private System.Windows.Forms.Label label21;
         private System.Windows.Forms.CheckBox MouseInvertCheckBox;
+        private System.Windows.Forms.Label label24;
+        private System.Windows.Forms.CheckBox checkboxMods;
     }
 }

--- a/SettingsForm.cs
+++ b/SettingsForm.cs
@@ -81,6 +81,7 @@ namespace CodeWalker
             GeometryCacheSizeUpDown.Value = Math.Min(Math.Max(Settings.Default.GPUGeometryCacheSize / 1048576, GeometryCacheSizeUpDown.Minimum), GeometryCacheSizeUpDown.Maximum);
             TextureCacheSizeUpDown.Value = Math.Min(Math.Max(Settings.Default.GPUTextureCacheSize / 1048576, TextureCacheSizeUpDown.Minimum), TextureCacheSizeUpDown.Maximum);
             CollisionCacheSizeUpDown.Value = Math.Min(Math.Max(Settings.Default.GPUBoundCompCacheSize / 1048576, CollisionCacheSizeUpDown.Minimum), CollisionCacheSizeUpDown.Maximum);
+            checkboxMods.Checked = Settings.Default.OnlyMods;
         }
 
 
@@ -319,6 +320,10 @@ namespace CodeWalker
         private void CollisionCacheSizeUpDown_ValueChanged(object sender, EventArgs e)
         {
             Settings.Default.GPUBoundCompCacheSize = (long)CollisionCacheSizeUpDown.Value * 1048576;
+        }
+        private void checkboxMods_CheckedChanged(object sender, EventArgs e)
+        {
+            Settings.Default.OnlyMods = checkboxMods.Checked;
         }
     }
 }

--- a/WorldForm.cs
+++ b/WorldForm.cs
@@ -4147,7 +4147,7 @@ namespace CodeWalker
             audiozones.Init(gameFileCache, UpdateStatus);
 
             UpdateStatus("Loading world...");
-            space.Init(gameFileCache, UpdateStatus);
+            space.Init(gameFileCache, UpdateStatus, Settings.Default.OnlyMods);
 
             UpdateStatus("World loaded");
 


### PR DESCRIPTION
I have been using this for a while.
Pretty useful if you work on some stuff like LC
it does not load game's ymap/nodes/navmeshes/collisions so it is pretty cool!

CodeWalker is also faster for its first load if toggle on.
Tested - should be working properly if my PR is complete