### PR TITLE
Dynamic generation of vertex layouts for GTAV vertex types

### DIFF
--- a/CodeWalker.Core/GameFiles/Resources/VertexType.cs
+++ b/CodeWalker.Core/GameFiles/Resources/VertexType.cs
@@ -7,7 +7,27 @@ using System.Threading.Tasks;
 
 namespace CodeWalker.GameFiles
 {
+    public enum VertexComponentType : ushort
+    {
+        Nothing = 0,
+        Float16Two = 1,
+        Float = 2,
+        Float16Four = 3,
+        Float_unk = 4,
+        Float2 = 5,
+        Float3 = 6,
+        Float4 = 7,
+        UByte4 = 8,
+        Color = 9,
+        Dec3N = 10,
+    }
 
+    public enum VertexDeclarationTypes : ulong
+    {
+        Types1 = 0x7755555555996996, // GTAV used by most drawables
+        Types2 = 0x030000000199A006, // GTAV used on cloth?
+        Types3 = 0x0300000001996006, // GTAV used on cloth?
+    }
 
     public enum VertexType : uint
     {
@@ -51,6 +71,49 @@ namespace CodeWalker.GameFiles
         PBBNCTTTX = 16863,
     }
 
+
+    //0x7755555555996996
+    public struct VertexTypeGTAV1
+    {
+        public Vector3 Position;
+        public uint BlendWeights;
+        public uint BlendIndices;
+        public Vector3 Normals;
+        public uint Colour0;
+        public uint Colour1;
+        public Vector2 Texcoords0;
+        public Vector2 Texcoords1;
+        public Vector2 Texcoords2;
+        public Vector2 Texcoords3;
+        public Vector2 Texcoords4;
+        public Vector2 Texcoords5;
+        public Vector2 Texcoords6;
+        public Vector2 Texcoords7;
+        public Vector4 Tangents;
+        public Vector4 Binormals;
+    }
+
+    //0x030000000199A006
+    public struct VertexTypeGTAV2
+    {
+        public Vector3 Position;
+        public uint Normals; // Packed as Dec3N 
+        public uint Colour0;
+        public uint Colour1;
+        public Half2 Texcoords0;
+        public Half4 Tangents;
+    }
+
+    //0x0300000001996006
+    public struct VertexTypeGTAV3
+    {
+        public Vector3 Position;
+        public Vector3 Normals;
+        public uint Colour0;
+        public uint Colour1;
+        public Half2 Texcoords0;
+        public Half4 Tangents;
+    }
 
     //vertex data to be used by the editor. TODO: maybe move somewhere else.
     public struct EditorVertex

--- a/Rendering/Shaders/BasicShader.cs
+++ b/Rendering/Shaders/BasicShader.cs
@@ -246,42 +246,42 @@ namespace CodeWalker.Rendering
 
 
             //supported layouts - requires Position, Normal, Colour, Texcoord
-            layouts.Add(VertexType.Default, new InputLayout(device, vspnctbytes, VertexTypeDefault.GetLayout()));
-            layouts.Add(VertexType.PNCH2, new InputLayout(device, vspnctbytes, VertexTypePNCH2.GetLayout()));//TODO?
-            layouts.Add(VertexType.PNCTT, new InputLayout(device, vspncttbytes, VertexTypePNCTT.GetLayout()));
-            layouts.Add(VertexType.PNCTTT, new InputLayout(device, vspnctttbytes, VertexTypePNCTTT.GetLayout()));
-            layouts.Add(VertexType.PNCCT, new InputLayout(device, vspncctbytes, VertexTypePNCCT.GetLayout()));
-            layouts.Add(VertexType.PNCCTT, new InputLayout(device, vspnccttbytes, VertexTypePNCCTT.GetLayout()));
-            layouts.Add(VertexType.PNCCTTTT, new InputLayout(device, vspncctttbytes, VertexTypePNCCTTTT.GetLayout()));//TODO..?
+            layouts.Add(VertexType.Default, new InputLayout(device, vspnctbytes, VertexTypeGTAV.GetLayout(VertexType.Default)));
+            layouts.Add(VertexType.PNCH2, new InputLayout(device, vspnctbytes, VertexTypeGTAV.GetLayout(VertexType.PNCH2, VertexDeclarationTypes.Types3)));//TODO?
+            layouts.Add(VertexType.PNCTT, new InputLayout(device, vspncttbytes, VertexTypeGTAV.GetLayout(VertexType.PNCTT)));
+            layouts.Add(VertexType.PNCTTT, new InputLayout(device, vspnctttbytes, VertexTypeGTAV.GetLayout(VertexType.PNCTTT)));
+            layouts.Add(VertexType.PNCCT, new InputLayout(device, vspncctbytes, VertexTypeGTAV.GetLayout(VertexType.PNCCT)));
+            layouts.Add(VertexType.PNCCTT, new InputLayout(device, vspnccttbytes, VertexTypeGTAV.GetLayout(VertexType.PNCCTT)));
+            layouts.Add(VertexType.PNCCTTTT, new InputLayout(device, vspncctttbytes, VertexTypeGTAV.GetLayout(VertexType.PNCCTTTT)));//TODO..?
 
 
 
             //normalmap layouts - requires Position, Normal, Colour, Texcoord, Tangent (X)
-            layouts.Add(VertexType.DefaultEx, new InputLayout(device, vspnctxbytes, VertexTypeDefaultEx.GetLayout()));
-            layouts.Add(VertexType.PCCH2H4, new InputLayout(device, vspnctxbytes, VertexTypePCCH2H4.GetLayout()));
-            layouts.Add(VertexType.PNCCTX, new InputLayout(device, vspncctxbytes, VertexTypePNCCTX.GetLayout()));
-            layouts.Add(VertexType.PNCTTX, new InputLayout(device, vspncttxbytes, VertexTypePNCTTX.GetLayout()));
-            layouts.Add(VertexType.PNCCTTX, new InputLayout(device, vspnccttxbytes, VertexTypePNCCTTX.GetLayout()));
-            layouts.Add(VertexType.PNCCTTX_2, new InputLayout(device, vspnccttxbytes, VertexTypePNCCTTX_2.GetLayout()));
-            layouts.Add(VertexType.PNCTTTX, new InputLayout(device, vspnctttxbytes, VertexTypePNCTTTX.GetLayout()));
-            layouts.Add(VertexType.PNCTTTX_2, new InputLayout(device, vspnctttxbytes, VertexTypePNCTTTX_2.GetLayout()));
-            layouts.Add(VertexType.PNCTTTX_3, new InputLayout(device, vspnctttxbytes, VertexTypePNCTTTX_3.GetLayout()));
-            layouts.Add(VertexType.PNCTTTTX, new InputLayout(device, vspnctttxbytes, VertexTypePNCTTTTX.GetLayout()));//TODO
-            layouts.Add(VertexType.PNCCTTTX, new InputLayout(device, vspncctttxbytes, VertexTypePNCCTTTX.GetLayout()));
+            layouts.Add(VertexType.DefaultEx, new InputLayout(device, vspnctxbytes, VertexTypeGTAV.GetLayout(VertexType.DefaultEx)));
+            layouts.Add(VertexType.PCCH2H4, new InputLayout(device, vspnctxbytes, VertexTypeGTAV.GetLayout(VertexType.PCCH2H4, VertexDeclarationTypes.Types2)));
+            layouts.Add(VertexType.PNCCTX, new InputLayout(device, vspncctxbytes, VertexTypeGTAV.GetLayout(VertexType.PNCCTX)));
+            layouts.Add(VertexType.PNCTTX, new InputLayout(device, vspncttxbytes, VertexTypeGTAV.GetLayout(VertexType.PNCTTX)));
+            layouts.Add(VertexType.PNCCTTX, new InputLayout(device, vspnccttxbytes, VertexTypeGTAV.GetLayout(VertexType.PNCCTTX)));
+            layouts.Add(VertexType.PNCCTTX_2, new InputLayout(device, vspnccttxbytes, VertexTypeGTAV.GetLayout(VertexType.PNCCTTX_2)));
+            layouts.Add(VertexType.PNCTTTX, new InputLayout(device, vspnctttxbytes, VertexTypeGTAV.GetLayout(VertexType.PNCTTTX)));
+            layouts.Add(VertexType.PNCTTTX_2, new InputLayout(device, vspnctttxbytes, VertexTypeGTAV.GetLayout(VertexType.PNCTTTX_2)));
+            layouts.Add(VertexType.PNCTTTX_3, new InputLayout(device, vspnctttxbytes, VertexTypeGTAV.GetLayout(VertexType.PNCTTTX_3)));
+            layouts.Add(VertexType.PNCTTTTX, new InputLayout(device, vspnctttxbytes, VertexTypeGTAV.GetLayout(VertexType.PNCTTTTX)));//TODO
+            layouts.Add(VertexType.PNCCTTTX, new InputLayout(device, vspncctttxbytes, VertexTypeGTAV.GetLayout(VertexType.PNCCTTTX)));
 
 
 
             //skinned layouts
-            layouts.Add(VertexType.PBBNCT, new InputLayout(device, vspbbnctbytes, VertexTypePBBNCT.GetLayout()));
-            layouts.Add(VertexType.PBBNCTX, new InputLayout(device, vspbbnctxbytes, VertexTypePBBNCTX.GetLayout()));
-            layouts.Add(VertexType.PBBNCTT, new InputLayout(device, vspbbncttbytes, VertexTypePBBNCTT.GetLayout()));
-            layouts.Add(VertexType.PBBNCTTT, new InputLayout(device, vspbbnctttbytes, VertexTypePBBNCTTT.GetLayout()));
-            layouts.Add(VertexType.PBBNCCT, new InputLayout(device, vspbbncctbytes, VertexTypePBBNCCT.GetLayout()));
-            layouts.Add(VertexType.PBBNCCTT, new InputLayout(device, vspbbncctbytes, VertexTypePBBNCCTT.GetLayout()));//TODO
-            layouts.Add(VertexType.PBBNCCTX, new InputLayout(device, vspbbncctxbytes, VertexTypePBBNCCTX.GetLayout()));
-            layouts.Add(VertexType.PBBNCTTX, new InputLayout(device, vspbbncttxbytes, VertexTypePBBNCTTX.GetLayout()));
-            layouts.Add(VertexType.PBBNCTTTX, new InputLayout(device, vspbbncttxbytes, VertexTypePBBNCTTTX.GetLayout()));//TODO
-            layouts.Add(VertexType.PBBNCCTTX, new InputLayout(device, vspbbncctxbytes, VertexTypePBBNCCTTX.GetLayout()));//TODO
+            layouts.Add(VertexType.PBBNCT, new InputLayout(device, vspbbnctbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCT)));
+            layouts.Add(VertexType.PBBNCTX, new InputLayout(device, vspbbnctxbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCTX)));
+            layouts.Add(VertexType.PBBNCTT, new InputLayout(device, vspbbncttbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCTT)));
+            layouts.Add(VertexType.PBBNCTTT, new InputLayout(device, vspbbnctttbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCTTT)));
+            layouts.Add(VertexType.PBBNCCT, new InputLayout(device, vspbbncctbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCCT)));
+            layouts.Add(VertexType.PBBNCCTT, new InputLayout(device, vspbbncctbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCCTT)));//TODO
+            layouts.Add(VertexType.PBBNCCTX, new InputLayout(device, vspbbncctxbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCCTX)));
+            layouts.Add(VertexType.PBBNCTTX, new InputLayout(device, vspbbncttxbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCTTX)));
+            layouts.Add(VertexType.PBBNCTTTX, new InputLayout(device, vspbbncttxbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCTTTX)));//TODO
+            layouts.Add(VertexType.PBBNCCTTX, new InputLayout(device, vspbbncctxbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCCTTX)));//TODO
             //PBBCCT todo
             //PBBNC todo
 

--- a/Rendering/Shaders/CableShader.cs
+++ b/Rendering/Shaders/CableShader.cs
@@ -102,7 +102,7 @@ namespace CodeWalker.Rendering
 
 
             //supported layout - requires Position, Normal, Colour, Texcoord
-            layouts.Add(VertexType.Default, new InputLayout(device, vsbytes, VertexTypeDefault.GetLayout()));
+            layouts.Add(VertexType.Default, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.Default)));
 
 
 

--- a/Rendering/Shaders/CloudsShader.cs
+++ b/Rendering/Shaders/CloudsShader.cs
@@ -118,7 +118,7 @@ namespace CodeWalker.Rendering
             VSModelVars = new GpuVarsBuffer<CloudsShaderVSModelVars>(device);
             PSSceneVars = new GpuVarsBuffer<CloudsShaderPSSceneVars>(device);
 
-            layout = new InputLayout(device, vsbytes, VertexTypeDefaultEx.GetLayout());
+            layout = new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.DefaultEx));
 
             texsampler = new SamplerState(device, new SamplerStateDescription()
             {

--- a/Rendering/Shaders/PathShader.cs
+++ b/Rendering/Shaders/PathShader.cs
@@ -61,7 +61,7 @@ namespace CodeWalker.Rendering
 
             VSSceneVars = new GpuVarsBuffer<PathShaderVSSceneVars>(device);
 
-            layout = new InputLayout(device, vsbytes, VertexTypePC.GetLayout());
+            layout = new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PC));
 
             cube = new UnitCube(device, boxvsbytes, true, false, true);
 

--- a/Rendering/Shaders/ShadowShader.cs
+++ b/Rendering/Shaders/ShadowShader.cs
@@ -97,35 +97,35 @@ namespace CodeWalker.Rendering
 
 
             //supported layouts - requires Position, Normal, Colour, Texcoord
-            layouts.Add(VertexType.Default, new InputLayout(device, vsbytes, VertexTypeDefault.GetLayout()));
-            layouts.Add(VertexType.DefaultEx, new InputLayout(device, vsbytes, VertexTypeDefaultEx.GetLayout()));
-            layouts.Add(VertexType.PNCCT, new InputLayout(device, vsbytes, VertexTypePNCCT.GetLayout()));
-            layouts.Add(VertexType.PNCCTTTT, new InputLayout(device, vsbytes, VertexTypePNCCTTTT.GetLayout()));
-            layouts.Add(VertexType.PNCTTTX, new InputLayout(device, vsbytes, VertexTypePNCTTTX.GetLayout()));
-            layouts.Add(VertexType.PNCTTTX_2, new InputLayout(device, vsbytes, VertexTypePNCTTTX_2.GetLayout()));
-            layouts.Add(VertexType.PNCTTTX_3, new InputLayout(device, vsbytes, VertexTypePNCTTTX_3.GetLayout()));
-            layouts.Add(VertexType.PNCTTTTX, new InputLayout(device, vsbytes, VertexTypePNCTTTTX.GetLayout()));
-            layouts.Add(VertexType.PNCTTX, new InputLayout(device, vsbytes, VertexTypePNCTTX.GetLayout()));
-            layouts.Add(VertexType.PNCCTTX, new InputLayout(device, vsbytes, VertexTypePNCCTTX.GetLayout()));
-            layouts.Add(VertexType.PNCCTTX_2, new InputLayout(device, vsbytes, VertexTypePNCCTTX_2.GetLayout()));
-            layouts.Add(VertexType.PNCCTTTX, new InputLayout(device, vsbytes, VertexTypePNCCTTTX.GetLayout()));
-            layouts.Add(VertexType.PNCCTT, new InputLayout(device, vsbytes, VertexTypePNCCTT.GetLayout()));
-            layouts.Add(VertexType.PNCCTX, new InputLayout(device, vsbytes, VertexTypePNCCTX.GetLayout()));
-            layouts.Add(VertexType.PNCH2, new InputLayout(device, vsbytes, VertexTypePNCH2.GetLayout()));
-            layouts.Add(VertexType.PCCH2H4, new InputLayout(device, vsbytes, VertexTypePCCH2H4.GetLayout()));
-            layouts.Add(VertexType.PNCTT, new InputLayout(device, vsbytes, VertexTypePNCTT.GetLayout()));
-            layouts.Add(VertexType.PNCTTT, new InputLayout(device, vsbytes, VertexTypePNCTTT.GetLayout()));
+            layouts.Add(VertexType.Default, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.Default)));
+            layouts.Add(VertexType.DefaultEx, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.DefaultEx)));
+            layouts.Add(VertexType.PNCCT, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PNCCT)));
+            layouts.Add(VertexType.PNCCTTTT, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PNCCTTTT)));
+            layouts.Add(VertexType.PNCTTTX, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PNCTTTX)));
+            layouts.Add(VertexType.PNCTTTX_2, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PNCTTTX_2)));
+            layouts.Add(VertexType.PNCTTTX_3, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PNCTTTX_3)));
+            layouts.Add(VertexType.PNCTTTTX, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PNCTTTTX)));
+            layouts.Add(VertexType.PNCTTX, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PNCTTX)));
+            layouts.Add(VertexType.PNCCTTX, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PNCCTTX)));
+            layouts.Add(VertexType.PNCCTTX_2, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PNCCTTX_2)));
+            layouts.Add(VertexType.PNCCTTTX, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PNCCTTTX)));
+            layouts.Add(VertexType.PNCCTT, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PNCCTT)));
+            layouts.Add(VertexType.PNCCTX, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PNCCTX)));
+            layouts.Add(VertexType.PNCH2, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PNCH2, VertexDeclarationTypes.Types3)));
+            layouts.Add(VertexType.PCCH2H4, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PCCH2H4, VertexDeclarationTypes.Types2)));
+            layouts.Add(VertexType.PNCTT, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PNCTT)));
+            layouts.Add(VertexType.PNCTTT, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PNCTTT)));
 
-            layouts.Add(VertexType.PBBNCT, new InputLayout(device, vssbytes, VertexTypePBBNCT.GetLayout()));
-            layouts.Add(VertexType.PBBNCTX, new InputLayout(device, vssbytes, VertexTypePBBNCTX.GetLayout()));
-            layouts.Add(VertexType.PBBNCTT, new InputLayout(device, vssbytes, VertexTypePBBNCTT.GetLayout()));
-            layouts.Add(VertexType.PBBNCTTT, new InputLayout(device, vssbytes, VertexTypePBBNCTTT.GetLayout()));
-            layouts.Add(VertexType.PBBNCCT, new InputLayout(device, vssbytes, VertexTypePBBNCCT.GetLayout()));
-            layouts.Add(VertexType.PBBNCCTT, new InputLayout(device, vssbytes, VertexTypePBBNCCTT.GetLayout()));//TODO
-            layouts.Add(VertexType.PBBNCCTX, new InputLayout(device, vssbytes, VertexTypePBBNCCTX.GetLayout()));
-            layouts.Add(VertexType.PBBNCTTX, new InputLayout(device, vssbytes, VertexTypePBBNCTTX.GetLayout()));
-            layouts.Add(VertexType.PBBNCTTTX, new InputLayout(device, vssbytes, VertexTypePBBNCTTTX.GetLayout()));//TODO
-            layouts.Add(VertexType.PBBNCCTTX, new InputLayout(device, vssbytes, VertexTypePBBNCCTTX.GetLayout()));//TODO
+            layouts.Add(VertexType.PBBNCT, new InputLayout(device, vssbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCT)));
+            layouts.Add(VertexType.PBBNCTX, new InputLayout(device, vssbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCTX)));
+            layouts.Add(VertexType.PBBNCTT, new InputLayout(device, vssbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCTT)));
+            layouts.Add(VertexType.PBBNCTTT, new InputLayout(device, vssbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCTTT)));
+            layouts.Add(VertexType.PBBNCCT, new InputLayout(device, vssbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCCT)));
+            layouts.Add(VertexType.PBBNCCTT, new InputLayout(device, vssbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCCTT)));//TODO
+            layouts.Add(VertexType.PBBNCCTX, new InputLayout(device, vssbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCCTX)));
+            layouts.Add(VertexType.PBBNCTTX, new InputLayout(device, vssbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCTTX)));
+            layouts.Add(VertexType.PBBNCTTTX, new InputLayout(device, vssbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCTTTX)));//TODO
+            layouts.Add(VertexType.PBBNCCTTX, new InputLayout(device, vssbytes, VertexTypeGTAV.GetLayout(VertexType.PBBNCCTTX)));//TODO
             //PBBCCT todo
             //PBBNC todo
 

--- a/Rendering/Shaders/SkydomeShader.cs
+++ b/Rendering/Shaders/SkydomeShader.cs
@@ -156,7 +156,7 @@ namespace CodeWalker.Rendering
 
             sundisc = new UnitDisc(device, 30, true);
             sunlayout = new InputLayout(device, sunvsbytes, sundisc.GetLayout());
-            skylayout = new InputLayout(device, skyvsbytes, VertexTypePTT.GetLayout());
+            skylayout = new InputLayout(device, skyvsbytes, VertexTypeGTAV.GetLayout(VertexType.PTT));
 
             moonquad = new UnitQuad(device, true);
             moonlayout = new InputLayout(device, moonvsbytes, moonquad.GetLayout());

--- a/Rendering/Shaders/TerrainShader.cs
+++ b/Rendering/Shaders/TerrainShader.cs
@@ -125,14 +125,14 @@ namespace CodeWalker.Rendering
             PSGeomVars = new GpuVarsBuffer<TerrainShaderPSGeomVars>(device);
 
             //supported layouts - requires Position, Normal, Colour, Texcoord
-            layouts.Add(VertexType.PNCCT, new InputLayout(device, vspncct, VertexTypePNCCT.GetLayout()));
-            layouts.Add(VertexType.PNCCTT, new InputLayout(device, vspncctt, VertexTypePNCCTT.GetLayout()));
-            layouts.Add(VertexType.PNCTTX, new InputLayout(device, vspncttx, VertexTypePNCTTX.GetLayout()));
-            layouts.Add(VertexType.PNCTTTX_3, new InputLayout(device, vspnctttx, VertexTypePNCTTTX_3.GetLayout()));
-            layouts.Add(VertexType.PNCCTX, new InputLayout(device, vspncctx, VertexTypePNCCTX.GetLayout()));
-            layouts.Add(VertexType.PNCCTTX, new InputLayout(device, vspnccttx, VertexTypePNCCTTX.GetLayout()));
-            layouts.Add(VertexType.PNCCTTX_2, new InputLayout(device, vspnccttx, VertexTypePNCCTTX_2.GetLayout()));
-            layouts.Add(VertexType.PNCCTTTX, new InputLayout(device, vspncctttx, VertexTypePNCCTTTX.GetLayout()));
+            layouts.Add(VertexType.PNCCT, new InputLayout(device, vspncct, VertexTypeGTAV.GetLayout(VertexType.PNCCT)));
+            layouts.Add(VertexType.PNCCTT, new InputLayout(device, vspncctt, VertexTypeGTAV.GetLayout(VertexType.PNCCTT)));
+            layouts.Add(VertexType.PNCTTX, new InputLayout(device, vspncttx, VertexTypeGTAV.GetLayout(VertexType.PNCTTX)));
+            layouts.Add(VertexType.PNCTTTX_3, new InputLayout(device, vspnctttx, VertexTypeGTAV.GetLayout(VertexType.PNCTTTX_3)));
+            layouts.Add(VertexType.PNCCTX, new InputLayout(device, vspncctx, VertexTypeGTAV.GetLayout(VertexType.PNCCTX)));
+            layouts.Add(VertexType.PNCCTTX, new InputLayout(device, vspnccttx, VertexTypeGTAV.GetLayout(VertexType.PNCCTTX)));
+            layouts.Add(VertexType.PNCCTTX_2, new InputLayout(device, vspnccttx, VertexTypeGTAV.GetLayout(VertexType.PNCCTTX_2)));
+            layouts.Add(VertexType.PNCCTTTX, new InputLayout(device, vspncctttx, VertexTypeGTAV.GetLayout(VertexType.PNCCTTTX)));
 
 
 

--- a/Rendering/Shaders/TreesLodShader.cs
+++ b/Rendering/Shaders/TreesLodShader.cs
@@ -88,7 +88,7 @@ namespace CodeWalker.Rendering
             PSEntityVars = new GpuVarsBuffer<TreesLodShaderPSEntityVars>(device);
 
             //layouts.Add(VertexType.PNCCT, new InputLayout(device, vsbytes, VertexTypePNCCT.GetLayout()));
-            layouts.Add(VertexType.PNCCTTTT, new InputLayout(device, vsbytes, VertexTypePNCCTTTT.GetLayout()));
+            layouts.Add(VertexType.PNCCTTTT, new InputLayout(device, vsbytes, VertexTypeGTAV.GetLayout(VertexType.PNCCTTTT)));
 
 
 

--- a/Rendering/Shaders/WaterShader.cs
+++ b/Rendering/Shaders/WaterShader.cs
@@ -138,10 +138,10 @@ namespace CodeWalker.Rendering
             PSSceneVars = new GpuVarsBuffer<WaterShaderPSSceneVars>(device);
             PSGeomVars = new GpuVarsBuffer<WaterShaderPSGeomVars>(device);
 
-            layouts.Add(VertexType.PT, new InputLayout(device, vsptbytes, VertexTypePT.GetLayout()));
-            layouts.Add(VertexType.PCT, new InputLayout(device, vspctbytes, VertexTypePCT.GetLayout()));
-            layouts.Add(VertexType.Default, new InputLayout(device, vspnctbytes, VertexTypeDefault.GetLayout()));
-            layouts.Add(VertexType.DefaultEx, new InputLayout(device, vspnctxbytes, VertexTypeDefaultEx.GetLayout()));
+            layouts.Add(VertexType.PT, new InputLayout(device, vsptbytes, VertexTypeGTAV.GetLayout(VertexType.PT)));
+            layouts.Add(VertexType.PCT, new InputLayout(device, vspctbytes, VertexTypeGTAV.GetLayout(VertexType.PCT)));
+            layouts.Add(VertexType.Default, new InputLayout(device, vspnctbytes, VertexTypeGTAV.GetLayout(VertexType.Default)));
+            layouts.Add(VertexType.DefaultEx, new InputLayout(device, vspnctxbytes, VertexTypeGTAV.GetLayout(VertexType.DefaultEx)));
 
             texsampler = new SamplerState(device, new SamplerStateDescription()
             {

--- a/Rendering/VertexTypes.cs
+++ b/Rendering/VertexTypes.cs
@@ -1,4 +1,5 @@
-﻿using SharpDX;
+﻿using CodeWalker.GameFiles;
+using SharpDX;
 using SharpDX.Direct3D11;
 using SharpDX.DXGI;
 using System;
@@ -9,7 +10,95 @@ using System.Threading.Tasks;
 
 namespace CodeWalker.Rendering
 {
+    public static class VertexTypeGTAV
+    {
+        public static string[] Semantics = new string[16]
+        {
+            "POSITION",
+            "BLENDWEIGHTS",
+            "BLENDINDICES",
+            "NORMAL",
+            "COLOR",
+            "COLOR",
+            "TEXCOORD",
+            "TEXCOORD",
+            "TEXCOORD",
+            "TEXCOORD",
+            "TEXCOORD",
+            "TEXCOORD",
+            "TEXCOORD",
+            "TEXCOORD",
+            "TANGENT",
+            "BINORMAL",
+        };
 
+        public static int GetVertexComponentTypeSizeInBytes(VertexComponentType type)
+        {
+            switch (type)
+            {
+                case VertexComponentType.Nothing: return 0;
+                case VertexComponentType.Float16Two: return 4;
+                case VertexComponentType.Float: return 4;
+                case VertexComponentType.Float16Four: return 8;
+                case VertexComponentType.Float_unk: return 0;
+                case VertexComponentType.Float2: return 8;
+                case VertexComponentType.Float3: return 12;
+                case VertexComponentType.Float4: return 16;
+                case VertexComponentType.UByte4: return 4;
+                case VertexComponentType.Color: return 4;
+                case VertexComponentType.Dec3N: return 4;
+                default: return 0;
+            }
+        }
+
+        public static Format GetDXGIFormat(VertexComponentType type)
+        {
+            switch (type)
+            {
+                case VertexComponentType.Nothing: return Format.Unknown;
+                case VertexComponentType.Float16Two: return Format.R16G16_Float;
+                case VertexComponentType.Float: return Format.R32_Float;
+                case VertexComponentType.Float16Four: return Format.R16G16B16A16_Float;
+                case VertexComponentType.Float_unk: return Format.Unknown;
+                case VertexComponentType.Float2: return Format.R32G32_Float;
+                case VertexComponentType.Float3: return Format.R32G32B32_Float;
+                case VertexComponentType.Float4: return Format.R32G32B32A32_Float;
+                case VertexComponentType.UByte4: return Format.R8G8B8A8_UInt;
+                case VertexComponentType.Color: return Format.R8G8B8A8_UNorm;
+                case VertexComponentType.Dec3N: return Format.R10G10B10A2_UNorm;
+                default: return Format.Unknown;
+            }
+        }
+
+        public static InputElement[] GetLayout(VertexType componentsFlags, VertexDeclarationTypes componentsTypes = VertexDeclarationTypes.Types1)
+        {
+            List<InputElement> inputElements = new List<InputElement>();
+
+            var types = (ulong)componentsTypes;
+            var flags = (uint)componentsFlags;
+
+            var offset = 0;
+
+            for (int k = 0; k < 16; k++)
+            {
+                if (((flags >> k) & 0x1) == 1)
+                {
+                    var componentType = (VertexComponentType)((types >> k * 4) & 0x0000000F);
+                    var componentTypeSize = GetVertexComponentTypeSizeInBytes(componentType);
+                    var format = GetDXGIFormat(componentType);
+
+                    if (componentTypeSize == 0 || format == Format.Unknown) continue;
+
+                    int index = inputElements.Where(e => e.SemanticName.Equals(Semantics[k])).Count();
+                    inputElements.Add(new InputElement(Semantics[k], index, format, offset, 0));
+
+                    offset += componentTypeSize;
+                }
+            }
+
+            return inputElements.ToArray();
+        }
+    }
 
 
     public struct VertexTypeDefault //id: 84500486, stride: 36, flags: 89, refs: 76099
@@ -18,17 +107,6 @@ namespace CodeWalker.Rendering
         public Vector3 Normal;
         public uint Colour;
         public Vector2 Texcoord;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 28, 0),
-            };
-        }
     }
 
     public struct VertexTypeDefaultEx //id: 168386566, stride: 52, flags: 16473, refs: 32337
@@ -38,18 +116,6 @@ namespace CodeWalker.Rendering
         public uint Colour;
         public Vector2 Texcoord;
         public Vector4 Tangent;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 28, 0),
-                new InputElement("TANGENT", 0, Format.R32G32B32A32_Float, 36, 0),
-            };
-        }
     }
 
     public struct VertexTypePNCCT //id: 93937670, stride: 40, flags: 121, refs: 31413
@@ -59,18 +125,6 @@ namespace CodeWalker.Rendering
         public uint Colour0;
         public uint Colour1;
         public Vector2 Texcoord;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("COLOR", 1, Format.R8G8B8A8_UNorm, 28, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 32, 0),
-            };
-        }
     }
 
     public struct VertexTypePNCCTTTT //id: 1436115100, stride: 64, flags: 1017, refs: 28673
@@ -83,21 +137,6 @@ namespace CodeWalker.Rendering
         public Vector2 Texcoord1;
         public Vector2 Texcoord2;
         public Vector2 Texcoord3;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("COLOR", 1, Format.R8G8B8A8_UNorm, 28, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 32, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 40, 0),
-                new InputElement("TEXCOORD", 2, Format.R32G32_Float, 48, 0),
-                new InputElement("TEXCOORD", 3, Format.R32G32_Float, 56, 0),
-            };
-        }
     }
 
     public struct VertexTypePBBNCCTTX //id: 1520003478, stride: 72, flags: 16639, refs: 11178
@@ -111,22 +150,6 @@ namespace CodeWalker.Rendering
         public Vector2 Texcoord0;
         public Vector2 Texcoord1;
         public Vector4 Tangents;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("BLENDWEIGHTS", 0, Format.R8G8B8A8_UNorm, 12, 0),
-                new InputElement("BLENDINDICES", 0, Format.R8G8B8A8_UNorm, 16, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 20, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 32, 0),
-                new InputElement("COLOR", 1, Format.R8G8B8A8_UNorm, 36, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 40, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 48, 0),
-                new InputElement("TANGENT", 0, Format.R32G32B32A32_Float, 56, 0),
-            };
-        }
     }
 
     public struct VertexTypePBBNCCT //id: 93940118, stride: 48, flags: 127, refs: 10396
@@ -138,20 +161,6 @@ namespace CodeWalker.Rendering
         public uint Colour0;
         public uint Colour1;
         public Vector2 Texcoord;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("BLENDWEIGHTS", 0, Format.R8G8B8A8_UNorm, 12, 0),
-                new InputElement("BLENDINDICES", 0, Format.R8G8B8A8_UNorm, 16, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 20, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 32, 0),
-                new InputElement("COLOR", 1, Format.R8G8B8A8_UNorm, 36, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 40, 0),
-            };
-        }
     }
 
     public struct VertexTypePNCTTTX //id: 1510563852, stride: 68, flags: 16857, refs: 3688
@@ -163,20 +172,6 @@ namespace CodeWalker.Rendering
         public Vector2 Texcoord1;
         public Vector2 Texcoord2;
         public Vector4 Tangents;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 28, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 36, 0),
-                new InputElement("TEXCOORD", 2, Format.R32G32_Float, 44, 0),
-                new InputElement("TANGENT", 0, Format.R32G32B32A32_Float, 52, 0),
-            };
-        }
     }
 
     public struct VertexTypePNCTTTX_2 //id: 168413446, stride: 68, flags: 19545, refs: 72
@@ -188,20 +183,6 @@ namespace CodeWalker.Rendering
         public Vector2 Texcoord1;
         public Vector2 Texcoord2;
         public Vector4 Tangents;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 28, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 36, 0),
-                new InputElement("TEXCOORD", 2, Format.R32G32_Float, 44, 0),
-                new InputElement("TANGENT", 0, Format.R32G32B32A32_Float, 52, 0),
-            };
-        }
     }
 
     public struct VertexTypePNCTTTX_3 //id: 1510563990, stride: 68, flags: 17113, refs: 43
@@ -213,20 +194,6 @@ namespace CodeWalker.Rendering
         public Vector2 Texcoord1;
         public Vector2 Texcoord2;
         public Vector4 Tangents;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 28, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 36, 0),
-                new InputElement("TEXCOORD", 2, Format.R32G32_Float, 44, 0),
-                new InputElement("TANGENT", 0, Format.R32G32B32A32_Float, 52, 0),
-            };
-        }
     }
 
     public struct VertexTypePNCTTX //id: 1510563846, stride: 60, flags: 16601, refs: 2712
@@ -237,19 +204,6 @@ namespace CodeWalker.Rendering
         public Vector2 Texcoord0;
         public Vector2 Texcoord1;
         public Vector4 Tangents;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 28, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 36, 0),
-                new InputElement("TANGENT", 0, Format.R32G32B32A32_Float, 44, 0),
-            };
-        }
     }
 
     public struct VertexTypePNCCTTX //id: 1520001030, stride: 64, flags: 16633, refs: 2635
@@ -261,20 +215,6 @@ namespace CodeWalker.Rendering
         public Vector2 Texcoord0;
         public Vector2 Texcoord1;
         public Vector4 Tangents;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("COLOR", 1, Format.R8G8B8A8_UNorm, 28, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 32, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 40, 0),
-                new InputElement("TANGENT", 0, Format.R32G32B32A32_Float, 48, 0),
-            };
-        }
     }
 
     public struct VertexTypePNCCTTTX //id: 1520001174, stride: 72, flags: 17145, refs: 2238
@@ -287,21 +227,6 @@ namespace CodeWalker.Rendering
         public Vector2 Texcoord1;
         public Vector2 Texcoord2;
         public Vector4 Tangents;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("COLOR", 1, Format.R8G8B8A8_UNorm, 28, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 32, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 40, 0),
-                new InputElement("TEXCOORD", 2, Format.R32G32_Float, 48, 0),
-                new InputElement("TANGENT", 0, Format.R32G32B32A32_Float, 56, 0),
-            };
-        }
     }
 
     public struct VertexTypePBBNCCTX //id: 177826198, stride: 64, flags: 16511, refs: 1990
@@ -314,21 +239,6 @@ namespace CodeWalker.Rendering
         public uint Colour1;
         public Vector2 Texcoord;
         public Vector4 Tangent;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("BLENDWEIGHTS", 0, Format.R8G8B8A8_UNorm, 12, 0),
-                new InputElement("BLENDINDICES", 0, Format.R8G8B8A8_UNorm, 16, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 20, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 32, 0),
-                new InputElement("COLOR", 1, Format.R8G8B8A8_UNorm, 36, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 40, 0),
-                new InputElement("TANGENT", 0, Format.R32G32B32A32_Float, 48, 0),
-            };
-        }
     }
 
     public struct VertexTypePNCCTTX_2 //id: 177823894, stride: 64, flags: 17017, refs: 1800
@@ -340,20 +250,6 @@ namespace CodeWalker.Rendering
         public Vector2 Texcoord0;
         public Vector2 Texcoord1;
         public Vector4 Tangent;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("COLOR", 1, Format.R8G8B8A8_UNorm, 28, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 32, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 40, 0),
-                new InputElement("TANGENT", 0, Format.R32G32B32A32_Float, 48, 0),
-            };
-        }
     }
 
     public struct VertexTypePBBNCTX //id: 168389014, stride: 60, flags: 16479, refs: 1736
@@ -365,20 +261,6 @@ namespace CodeWalker.Rendering
         public uint Colour0;
         public Vector2 Texcoord;
         public Vector4 Tangent;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("BLENDWEIGHTS", 0, Format.R8G8B8A8_UNorm, 12, 0),
-                new InputElement("BLENDINDICES", 0, Format.R8G8B8A8_UNorm, 16, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 20, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 32, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 36, 0),
-                new InputElement("TANGENT", 0, Format.R32G32B32A32_Float, 44, 0),
-            };
-        }
     }
 
     public struct VertexTypePNCCTT //id: 1436114950, stride: 48, flags: 249, refs: 1704
@@ -389,19 +271,6 @@ namespace CodeWalker.Rendering
         public uint Colour1;
         public Vector2 Texcoord0;
         public Vector2 Texcoord1;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("COLOR", 1, Format.R8G8B8A8_UNorm, 28, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 32, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 40, 0),
-            };
-        }
     }
 
     public struct VertexTypePNCCTX //id: 177823750, stride: 56, flags: 16505, refs: 1338
@@ -412,19 +281,6 @@ namespace CodeWalker.Rendering
         public uint Colour1;
         public Vector2 Texcoord;
         public Vector4 Tangent;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("COLOR", 1, Format.R8G8B8A8_UNorm, 28, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 32, 0),
-                new InputElement("TANGENT", 0, Format.R32G32B32A32_Float, 40, 0),
-            };
-        }
     }
 
     public struct VertexTypePCT //id: 84475910, stride: 24, flags: 81, refs: 102
@@ -432,31 +288,12 @@ namespace CodeWalker.Rendering
         public Vector3 Position;
         public uint Colour;
         public Vector2 Texcoord;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 12, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 16, 0),
-            };
-        }
     }
 
     public struct VertexTypePT //id: 83886086, stride: 20, flags: 65, refs: 159 //water pools seem to use this
     {
         public Vector3 Position;
         public Vector2 Texcoord;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 12, 0),
-            };
-        }
     }
 
     public struct VertexTypePTT //id: 1426063366, stride: 28, flags: 193, refs: 1 (skydome)
@@ -464,16 +301,6 @@ namespace CodeWalker.Rendering
         public Vector3 Position;
         public Vector2 Texcoord0;
         public Vector2 Texcoord1;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 12, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 20, 0),
-            };
-        }
     }
 
     public struct VertexTypePNC //id: 614406, stride: 28, flags: 25, refs: 380 // tunnel shadow casters seem use this
@@ -481,16 +308,6 @@ namespace CodeWalker.Rendering
         public Vector3 Position;
         public Vector3 Normal;
         public uint Colour;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-            };
-        }
     }
 
     public struct VertexTypePBBNCT //id: 84502934, stride: 44, flags: 95, refs: 806
@@ -501,34 +318,12 @@ namespace CodeWalker.Rendering
         public Vector3 Normal;
         public uint Colour0;
         public Vector2 Texcoord;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("BLENDWEIGHTS", 0, Format.R8G8B8A8_UNorm, 12, 0),
-                new InputElement("BLENDINDICES", 0, Format.R8G8B8A8_UNorm, 16, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 20, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 32, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 36, 0),
-            };
-        }
     }
 
     public struct VertexTypePC //id: 589830, stride: 16, flags: 17, refs: 405
     {
         public Vector3 Position;
         public uint Colour;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 12, 0),
-            };
-        }
     }
 
     public struct VertexTypePCC //id: 2454, stride: 20, flags: 7, refs: 242
@@ -536,16 +331,6 @@ namespace CodeWalker.Rendering
         public Vector3 Position;
         public uint Colour0;
         public uint Colour1;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 12, 0),
-                new InputElement("COLOR", 1, Format.R8G8B8A8_UNorm, 16, 0),
-            };
-        }
     }
 
     public struct VertexTypePNCTTTT //id: 1426677916, stride: 60, flags: 985, refs: 150
@@ -557,20 +342,6 @@ namespace CodeWalker.Rendering
         public Vector2 Texcoord1;
         public Vector2 Texcoord2;
         public Vector2 Texcoord3;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 28, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 36, 0),
-                new InputElement("TEXCOORD", 2, Format.R32G32_Float, 44, 0),
-                new InputElement("TEXCOORD", 3, Format.R32G32_Float, 52, 0),
-            };
-        }
     }
 
     public struct VertexTypePBBNCCTT //id: 1436117398, stride: 56, flags: 255, refs: 99
@@ -583,21 +354,6 @@ namespace CodeWalker.Rendering
         public uint Colour3;
         public Vector2 Texcoord0;
         public Vector2 Texcoord1;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("BLENDWEIGHTS", 0, Format.R8G8B8A8_UNorm, 12, 0),
-                new InputElement("BLENDINDICES", 0, Format.R8G8B8A8_UNorm, 16, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 20, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 32, 0),
-                new InputElement("COLOR", 1, Format.R8G8B8A8_UNorm, 36, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 40, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 48, 0),
-            };
-        }
     }
 
     public struct VertexTypePCTT //id: 1426653190, stride: 32, flags: 209, refs: 79
@@ -606,17 +362,6 @@ namespace CodeWalker.Rendering
         public uint Colour;
         public Vector2 Texcoord0;
         public Vector2 Texcoord1;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 12, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 16, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 24, 0),
-            };
-        }
     }
 
     public struct VertexTypePNCTTTTX //id: 1510590726, stride: 76, flags: 19673, refs: 3   //beach graffiti trees -  normal_spec_detail_dpm_vertdecal_tnt.sps
@@ -629,21 +374,6 @@ namespace CodeWalker.Rendering
         public Vector2 Texcoord2;
         public Vector2 Texcoord3;
         public Vector4 Tangent;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 28, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 36, 0),
-                new InputElement("TEXCOORD", 2, Format.R32G32_Float, 44, 0),
-                new InputElement("TEXCOORD", 3, Format.R32G32_Float, 52, 0),
-                new InputElement("TANGENT", 0, Format.R32G32B32A32_Float, 60, 0),
-            };
-        }
     }
 
     public struct VertexTypePBBCCT //id: 93915542, stride: 36, flags: 119, refs: 2
@@ -654,19 +384,6 @@ namespace CodeWalker.Rendering
         public uint Colour0;
         public uint Colour1;
         public Vector2 Texcoord;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("BLENDWEIGHTS", 0, Format.R8G8B8A8_UNorm, 12, 0),
-                new InputElement("BLENDINDICES", 0, Format.R8G8B8A8_UNorm, 16, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 20, 0),
-                new InputElement("COLOR", 1, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 28, 0),
-            };
-        }
     }
 
     public struct VertexTypePBBNC //id: 616854, stride: 36, flags: 31, refs: 1
@@ -676,18 +393,6 @@ namespace CodeWalker.Rendering
         public uint BlendIndices;
         public Vector3 Normal;
         public uint Colour0;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("BLENDWEIGHTS", 0, Format.R8G8B8A8_UNorm, 12, 0),
-                new InputElement("BLENDINDICES", 0, Format.R8G8B8A8_UNorm, 16, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 20, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 32, 0),
-            };
-        }
     }
 
 
@@ -704,19 +409,6 @@ namespace CodeWalker.Rendering
         public ushort TangentY;
         public ushort TangentZ;
         public ushort TangentW;
-
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R8G8B8A8_SNorm, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 16, 0),
-                new InputElement("TEXCOORD", 0, Format.R16G16_Float, 20, 0),
-                new InputElement("TANGENT", 0, Format.R16G16B16A16_Float, 24, 0),
-            };
-        }
     }
 
     public struct VertexTypePNCH2 //id: 17391622, stride: 32, flags: 89, types: 216172782140612614, refs: 1174 (yft only) - frag cloth default
@@ -726,17 +418,6 @@ namespace CodeWalker.Rendering
         public uint Colour;
         public ushort TexcoordX;// Vector2 Texcoord;
         public ushort TexcoordY;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("TEXCOORD", 0, Format.R16G16_Float, 28, 0),
-            };
-        }
     }
 
 
@@ -750,20 +431,6 @@ namespace CodeWalker.Rendering
         public uint Colour0;
         public Vector2 Texcoord0;
         public Vector2 Texcoord1;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("BLENDWEIGHTS", 0, Format.R8G8B8A8_UNorm, 12, 0),
-                new InputElement("BLENDINDICES", 0, Format.R8G8B8A8_UNorm, 16, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 20, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 32, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 36, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 44, 0),
-            };
-        }
     }
 
     public struct VertexTypePBBNCTTX //id: 1510566294, stride: 68, flags: 16607, types: 8598872888530528662, refs: 1478 (+9)
@@ -776,21 +443,6 @@ namespace CodeWalker.Rendering
         public Vector2 Texcoord0;
         public Vector2 Texcoord1;
         public Vector4 Tangent;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("BLENDWEIGHTS", 0, Format.R8G8B8A8_UNorm, 12, 0),
-                new InputElement("BLENDINDICES", 0, Format.R8G8B8A8_UNorm, 16, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 20, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 32, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 36, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 44, 0),
-                new InputElement("TANGENT", 0, Format.R32G32B32A32_Float, 52, 0),
-            };
-        }
     }
 
     public struct VertexTypePBBNCTTT //id: 1426680220, stride: 60, flags: 479, types: 8598872888530528662, refs: 1290
@@ -803,21 +455,6 @@ namespace CodeWalker.Rendering
         public Vector2 Texcoord0;
         public Vector2 Texcoord1;
         public Vector2 Texcoord2;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("BLENDWEIGHTS", 0, Format.R8G8B8A8_UNorm, 12, 0),
-                new InputElement("BLENDINDICES", 0, Format.R8G8B8A8_UNorm, 16, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 20, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 32, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 36, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 44, 0),
-                new InputElement("TEXCOORD", 2, Format.R32G32_Float, 52, 0),
-            };
-        }
     }
 
     public struct VertexTypePNCTT //id: 1426677766, stride: 44, flags: 217, types: 8598872888530528662, refs: 4434
@@ -827,18 +464,6 @@ namespace CodeWalker.Rendering
         public uint Colour;
         public Vector2 Texcoord0;
         public Vector2 Texcoord1;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 28, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 36, 0),
-            };
-        }
     }
 
     public struct VertexTypePNCTTT //id: 1426677772, stride: 52, flags: 473, types: 8598872888530528662, refs: 65
@@ -849,19 +474,6 @@ namespace CodeWalker.Rendering
         public Vector2 Texcoord0;
         public Vector2 Texcoord1;
         public Vector2 Texcoord2;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 12, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 24, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 28, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 36, 0),
-                new InputElement("TEXCOORD", 2, Format.R32G32_Float, 44, 0),
-            };
-        }
     }
 
 
@@ -877,22 +489,6 @@ namespace CodeWalker.Rendering
         public Vector2 Texcoord1;
         public Vector2 Texcoord2;
         public Vector4 Tangent;
-
-        public static InputElement[] GetLayout()
-        {
-            return new[]
-            {
-                new InputElement("POSITION", 0, Format.R32G32B32_Float, 0, 0),
-                new InputElement("BLENDWEIGHTS", 0, Format.R8G8B8A8_UNorm, 12, 0),
-                new InputElement("BLENDINDICES", 0, Format.R8G8B8A8_UNorm, 16, 0),
-                new InputElement("NORMAL", 0, Format.R32G32B32_Float, 20, 0),
-                new InputElement("COLOR", 0, Format.R8G8B8A8_UNorm, 32, 0),
-                new InputElement("TEXCOORD", 0, Format.R32G32_Float, 36, 0),
-                new InputElement("TEXCOORD", 1, Format.R32G32_Float, 44, 0),
-                new InputElement("TEXCOORD", 2, Format.R32G32_Float, 52, 0),
-                new InputElement("TANGENT", 0, Format.R32G32B32A32_Float, 60, 0),
-            };
-        }
     }
 
 


### PR DESCRIPTION
- VertexComponentType : specifies what each nibble of `VertexDeclarationTypes` is
- VertexDeclarationTypes : the known vertex declaration types used in GTAV

- VertexTypeGTAV : is a helper class which generates the correct layout using `VertexDeclarationTypes`, `VertexType`, `VertexComponentType`

Suggestions:

1. Rename `VertexType` to `VertexDeclarationFlags` and replace enum values with HEX ones
2. If Bounds rendering don't require texcoords, use a PNC vertex instead of PNCT one. (requires a new BasicVS_PNC shader)