### PR TITLE
Improve Xml parsing

### DIFF
--- a/CodeWalker.Core/CodeWalker.Core.csproj
+++ b/CodeWalker.Core/CodeWalker.Core.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="SharpDX" Version="4.2.0" />
     <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CodeWalker.Core/Utils/Xml.cs
+++ b/CodeWalker.Core/Utils/Xml.cs
@@ -414,36 +414,14 @@ namespace CodeWalker
 
         public static Vector2[] GetRawVector2Array(XmlNode node)
         {
-            if (node == null) return new Vector2[0];
-            float x = 0f;
-            float y = 0f;
+            float[] data = GetRawFloatArray(node);
             var items = new List<Vector2>();
-            var split = node.InnerText.Split('\n');// Regex.Split(node.InnerText, @"[\s\r\n\t]");
-            for (int i = 0; i < split.Length; i++)
+
+            if (data.Length % 2 != 0) return null;
+
+            for (int i = 0; i < data.Length; i += 2)
             {
-                var s = split[i]?.Trim();
-                if (string.IsNullOrEmpty(s)) continue;
-                var split2 = s.Split(',');// Regex.Split(s, @"[\s\t]");
-                int c = 0;
-                x = 0f; y = 0f;
-                for (int n = 0; n < split2.Length; n++)
-                {
-                    var ts = split2[n]?.Trim();
-                    if (string.IsNullOrEmpty(ts)) continue;
-                    var f = FloatUtil.Parse(ts);
-                    switch (c)
-                    {
-                        case 0: x = f; break;
-                        case 1: y = f; break;
-                        //case 2: z = f; break;
-                    }
-                    c++;
-                }
-                if (c >= 2)
-                {
-                    var val = new Vector2(x, y);
-                    items.Add(val);
-                }
+                items.Add(new Vector2(data[i], data[i + 1]));
             }
 
             return items.ToArray();
@@ -456,37 +434,14 @@ namespace CodeWalker
 
         public static Vector3[] GetRawVector3Array(XmlNode node)
         {
-            if (node == null) return new Vector3[0];
-            float x = 0f;
-            float y = 0f;
-            float z = 0f;
+            float[] data = GetRawFloatArray(node);
             var items = new List<Vector3>();
-            var split = node.InnerText.Split('\n');// Regex.Split(node.InnerText, @"[\s\r\n\t]");
-            for (int i = 0; i < split.Length; i++)
+
+            if (data.Length % 3 != 0) return null;
+
+            for (int i = 0; i < data.Length; i += 3)
             {
-                var s = split[i]?.Trim();
-                if (string.IsNullOrEmpty(s)) continue;
-                var split2 = s.Split(',');// Regex.Split(s, @"[\s\t]");
-                int c = 0;
-                x = 0f; y = 0f;
-                for (int n = 0; n < split2.Length; n++)
-                {
-                    var ts = split2[n]?.Trim();
-                    if (string.IsNullOrEmpty(ts)) continue;
-                    var f = FloatUtil.Parse(ts);
-                    switch (c)
-                    {
-                        case 0: x = f; break;
-                        case 1: y = f; break;
-                        case 2: z = f; break;
-                    }
-                    c++;
-                }
-                if (c >= 3)
-                {
-                    var val = new Vector3(x, y, z);
-                    items.Add(val);
-                }
+                items.Add(new Vector3(data[i], data[i + 1], data[i + 2]));
             }
 
             return items.ToArray();
@@ -505,39 +460,14 @@ namespace CodeWalker
 
         public static Vector4[] GetRawVector4Array(XmlNode node)
         {
-            if (node == null) return new Vector4[0];
-            float x = 0f;
-            float y = 0f;
-            float z = 0f;
-            float w = 0f;
+            float[] data = GetRawFloatArray(node);
             var items = new List<Vector4>();
-            var split = node.InnerText.Split('\n');// Regex.Split(node.InnerText, @"[\s\r\n\t]");
-            for (int i = 0; i < split.Length; i++)
+
+            if (data.Length % 4 != 0) return null;
+
+            for (int i = 0; i < data.Length; i += 4)
             {
-                var s = split[i]?.Trim();
-                if (string.IsNullOrEmpty(s)) continue;
-                var split2 = s.Split(',');// Regex.Split(s, @"[\s\t]");
-                int c = 0;
-                x = 0f; y = 0f;
-                for (int n = 0; n < split2.Length; n++)
-                {
-                    var ts = split2[n]?.Trim();
-                    if (string.IsNullOrEmpty(ts)) continue;
-                    var f = FloatUtil.Parse(ts);
-                    switch (c)
-                    {
-                        case 0: x = f; break;
-                        case 1: y = f; break;
-                        case 2: z = f; break;
-                        case 3: w = f; break;
-                    }
-                    c++;
-                }
-                if (c >= 4)
-                {
-                    var val = new Vector4(x, y, z, w);
-                    items.Add(val);
-                }
+                items.Add(new Vector4(data[i], data[i + 1], data[i + 2], data[i + 3]));
             }
 
             return items.ToArray();

--- a/CodeWalker.Core/Utils/Xml.cs
+++ b/CodeWalker.Core/Utils/Xml.cs
@@ -216,9 +216,7 @@ namespace CodeWalker
             int length = 0;
             for (int i = 0; i < readOnlySpan.Length; i++)
             {
-                char singleChar = readOnlySpan[i];
-
-                if (!char.IsWhiteSpace(singleChar))
+                if (!char.IsWhiteSpace(readOnlySpan[i]))
                 {
                     length++;
                     continue;
@@ -257,9 +255,7 @@ namespace CodeWalker
             int length = 0;
             for (int i = 0; i < readOnlySpan.Length; i++)
             {
-                char singleChar = readOnlySpan[i];
-
-                if (!char.IsWhiteSpace(singleChar))
+                if (!char.IsWhiteSpace(readOnlySpan[i]))
                 {
                     length++;
                     continue;
@@ -298,9 +294,7 @@ namespace CodeWalker
             int length = 0;
             for (int i = 0; i < readOnlySpan.Length; i++)
             {
-                char singleChar = readOnlySpan[i];
-
-                if (!char.IsWhiteSpace(singleChar))
+                if (!char.IsWhiteSpace(readOnlySpan[i]))
                 {
                     length++;
                     continue;
@@ -339,9 +333,7 @@ namespace CodeWalker
             int length = 0;
             for (int i = 0; i < readOnlySpan.Length; i++)
             {
-                char singleChar = readOnlySpan[i];
-
-                if (!char.IsWhiteSpace(singleChar))
+                if (!char.IsWhiteSpace(readOnlySpan[i]))
                 {
                     length++;
                     continue;
@@ -380,9 +372,7 @@ namespace CodeWalker
             int length = 0;
             for (int i = 0; i < readOnlySpan.Length; i++)
             {
-                char singleChar = readOnlySpan[i];
-
-                if (!char.IsWhiteSpace(singleChar))
+                if (!char.IsWhiteSpace(readOnlySpan[i]))
                 {
                     length++;
                     continue;

--- a/CodeWalker.Core/Utils/Xml.cs
+++ b/CodeWalker.Core/Utils/Xml.cs
@@ -217,20 +217,33 @@ namespace CodeWalker
             for (int i = 0; i < readOnlySpan.Length; i++)
             {
                 if (!char.IsWhiteSpace(readOnlySpan[i]))
-                {
+                { 
                     length++;
-                    continue;
-                }
 
-                if (length > 0)
+                    // If it's last char
+                    if (i == readOnlySpan.Length - 1)
+                    {
+                        var item = readOnlySpan.Slice(i - length + 1, length).ToString();
+
+                        var val = Convert.ToByte(item, fromBase);
+                        data.Add(val);
+
+                        length = 0;
+                    }
+                }
+                else
                 {
-                    var item = readOnlySpan.Slice(i - length, length).ToString();
+                    // If previous weren't other whitespaces
+                    if (length > 0)
+                    {
+                        var item = readOnlySpan.Slice(i - length, length).ToString();
 
-                    var val = Convert.ToByte(item, fromBase);
-                    data.Add(val);
+                        var val = Convert.ToByte(item, fromBase);
+                        data.Add(val);
+
+                        length = 0;
+                    }
                 }
-
-                length = 0;
             }
             return data.ToArray();
         }
@@ -258,18 +271,31 @@ namespace CodeWalker
                 if (!char.IsWhiteSpace(readOnlySpan[i]))
                 {
                     length++;
-                    continue;
-                }
 
-                if (length > 0)
+                    // If it's last char
+                    if (i == readOnlySpan.Length - 1)
+                    {
+                        var item = readOnlySpan.Slice(i - length + 1, length).ToString();
+
+                        if(ushort.TryParse(item, out ushort val))
+                            data.Add(val);
+
+                        length = 0;
+                    }
+                }
+                else
                 {
-                    var item = readOnlySpan.Slice(i - length, length).ToString();
+                    // If previous weren't other whitespaces
+                    if (length > 0)
+                    {
+                        var item = readOnlySpan.Slice(i - length, length).ToString();
 
-                    if (ushort.TryParse(item, out ushort val))
-                        data.Add(val);
+                        if (ushort.TryParse(item, out ushort val))
+                            data.Add(val);
+
+                        length = 0;
+                    }
                 }
-
-                length = 0;
             }
             return data.ToArray();
         }
@@ -297,18 +323,31 @@ namespace CodeWalker
                 if (!char.IsWhiteSpace(readOnlySpan[i]))
                 {
                     length++;
-                    continue;
-                }
 
-                if (length > 0)
+                    // If it's last char
+                    if (i == readOnlySpan.Length - 1)
+                    {
+                        var item = readOnlySpan.Slice(i - length + 1, length).ToString();
+
+                        if (uint.TryParse(item, out uint val))
+                            data.Add(val);
+
+                        length = 0;
+                    }
+                }
+                else
                 {
-                    var item = readOnlySpan.Slice(i - length, length).ToString();
+                    // If previous weren't other whitespaces
+                    if (length > 0)
+                    {
+                        var item = readOnlySpan.Slice(i - length, length).ToString();
 
-                    if (uint.TryParse(item, out uint val))
-                        data.Add(val);
+                        if (uint.TryParse(item, out uint val))
+                            data.Add(val);
+
+                        length = 0;
+                    }
                 }
-
-                length = 0;
             }
             return data.ToArray();
         }
@@ -336,18 +375,31 @@ namespace CodeWalker
                 if (!char.IsWhiteSpace(readOnlySpan[i]))
                 {
                     length++;
-                    continue;
-                }
 
-                if (length > 0)
+                    // If it's last char
+                    if (i == readOnlySpan.Length - 1)
+                    {
+                        var item = readOnlySpan.Slice(i - length + 1, length).ToString();
+
+                        if (int.TryParse(item, out int val))
+                            data.Add(val);
+
+                        length = 0;
+                    }
+                }
+                else
                 {
-                    var item = readOnlySpan.Slice(i - length, length).ToString();
+                    // If previous weren't other whitespaces
+                    if (length > 0)
+                    {
+                        var item = readOnlySpan.Slice(i - length, length).ToString();
 
-                    if (int.TryParse(item, out int val))
-                        data.Add(val);
+                        if (int.TryParse(item, out int val))
+                            data.Add(val);
+
+                        length = 0;
+                    }
                 }
-
-                length = 0;
             }
             return data.ToArray();
         }
@@ -375,18 +427,31 @@ namespace CodeWalker
                 if (!char.IsWhiteSpace(readOnlySpan[i]))
                 {
                     length++;
-                    continue;
-                }
 
-                if (length > 0)
+                    // If it's last char
+                    if (i == readOnlySpan.Length - 1)
+                    {
+                        var item = readOnlySpan.Slice(i - length + 1, length).ToString();
+
+                        var val = FloatUtil.Parse(item);
+                        data.Add(val);
+
+                        length = 0;
+                    }
+                }
+                else
                 {
-                    var item = readOnlySpan.Slice(i - length, length).ToString();
+                    // If previous weren't other whitespaces
+                    if (length > 0)
+                    {
+                        var item = readOnlySpan.Slice(i - length, length).ToString();
 
-                    var val = FloatUtil.Parse(item);
-                    data.Add(val);
+                        var val = FloatUtil.Parse(item);
+                        data.Add(val);
+
+                        length = 0;
+                    }
                 }
-
-                length = 0;
             }
             return data.ToArray();
         }

--- a/CodeWalker.Core/Utils/Xml.cs
+++ b/CodeWalker.Core/Utils/Xml.cs
@@ -240,17 +240,28 @@ namespace CodeWalker
         {
             if (node == null) return new ushort[0];
             var data = new List<ushort>();
-            var split = Regex.Split(node.InnerText, @"[\s\r\n\t]");
-            for (int i = 0; i < split.Length; i++)
+            ReadOnlySpan<char> readOnlySpan = node.InnerText.AsSpan();
+
+            int lenght = 0;
+            for (int i = 0; i < readOnlySpan.Length; i++)
             {
-                if (!string.IsNullOrEmpty(split[i]))
+                char singleChar = readOnlySpan[i];
+
+                if (!char.IsWhiteSpace(singleChar))
                 {
-                    var str = split[i];
-                    if (string.IsNullOrEmpty(str)) continue;
-                    var val = (ushort)0;
-                    ushort.TryParse(str, out val);
-                    data.Add(val);
+                    lenght++;
+                    continue;
                 }
+
+                if (lenght > 0)
+                {
+                    var item = readOnlySpan.Slice(i - lenght, lenght).ToString();
+
+                    if (ushort.TryParse(item, out ushort val))
+                        data.Add(val);
+                }
+
+                lenght = 0;
             }
             return data.ToArray();
         }

--- a/CodeWalker.Core/Utils/Xml.cs
+++ b/CodeWalker.Core/Utils/Xml.cs
@@ -213,26 +213,26 @@ namespace CodeWalker
             var data = new List<byte>();
             ReadOnlySpan<char> readOnlySpan = node.InnerText.AsSpan();
 
-            int lenght = 0;
+            int length = 0;
             for (int i = 0; i < readOnlySpan.Length; i++)
             {
                 char singleChar = readOnlySpan[i];
 
                 if (!char.IsWhiteSpace(singleChar))
                 {
-                    lenght++;
+                    length++;
                     continue;
                 }
 
-                if (lenght > 0)
+                if (length > 0)
                 {
-                    var item = readOnlySpan.Slice(i - lenght, lenght).ToString();
+                    var item = readOnlySpan.Slice(i - length, length).ToString();
 
                     var val = Convert.ToByte(item, fromBase);
                     data.Add(val);
                 }
 
-                lenght = 0;
+                length = 0;
             }
             return data.ToArray();
         }
@@ -254,26 +254,26 @@ namespace CodeWalker
             var data = new List<ushort>();
             ReadOnlySpan<char> readOnlySpan = node.InnerText.AsSpan();
 
-            int lenght = 0;
+            int length = 0;
             for (int i = 0; i < readOnlySpan.Length; i++)
             {
                 char singleChar = readOnlySpan[i];
 
                 if (!char.IsWhiteSpace(singleChar))
                 {
-                    lenght++;
+                    length++;
                     continue;
                 }
 
-                if (lenght > 0)
+                if (length > 0)
                 {
-                    var item = readOnlySpan.Slice(i - lenght, lenght).ToString();
+                    var item = readOnlySpan.Slice(i - length, length).ToString();
 
                     if (ushort.TryParse(item, out ushort val))
                         data.Add(val);
                 }
 
-                lenght = 0;
+                length = 0;
             }
             return data.ToArray();
         }
@@ -295,26 +295,26 @@ namespace CodeWalker
             var data = new List<uint>();
             ReadOnlySpan<char> readOnlySpan = node.InnerText.AsSpan();
 
-            int lenght = 0;
+            int length = 0;
             for (int i = 0; i < readOnlySpan.Length; i++)
             {
                 char singleChar = readOnlySpan[i];
 
                 if (!char.IsWhiteSpace(singleChar))
                 {
-                    lenght++;
+                    length++;
                     continue;
                 }
 
-                if (lenght > 0)
+                if (length > 0)
                 {
-                    var item = readOnlySpan.Slice(i - lenght, lenght).ToString();
+                    var item = readOnlySpan.Slice(i - length, length).ToString();
 
                     if (uint.TryParse(item, out uint val))
                         data.Add(val);
                 }
 
-                lenght = 0;
+                length = 0;
             }
             return data.ToArray();
         }
@@ -336,26 +336,26 @@ namespace CodeWalker
             var data = new List<int>();
             ReadOnlySpan<char> readOnlySpan = node.InnerText.AsSpan();
 
-            int lenght = 0;
+            int length = 0;
             for (int i = 0; i < readOnlySpan.Length; i++)
             {
                 char singleChar = readOnlySpan[i];
 
                 if (!char.IsWhiteSpace(singleChar))
                 {
-                    lenght++;
+                    length++;
                     continue;
                 }
 
-                if (lenght > 0)
+                if (length > 0)
                 {
-                    var item = readOnlySpan.Slice(i - lenght, lenght).ToString();
+                    var item = readOnlySpan.Slice(i - length, length).ToString();
 
                     if (int.TryParse(item, out int val))
                         data.Add(val);
                 }
 
-                lenght = 0;
+                length = 0;
             }
             return data.ToArray();
         }
@@ -377,26 +377,26 @@ namespace CodeWalker
             var data = new List<float>();
             ReadOnlySpan<char> readOnlySpan = node.InnerText.AsSpan();
 
-            int lenght = 0;
+            int length = 0;
             for (int i = 0; i < readOnlySpan.Length; i++)
             {
                 char singleChar = readOnlySpan[i];
 
                 if (!char.IsWhiteSpace(singleChar))
                 {
-                    lenght++;
+                    length++;
                     continue;
                 }
 
-                if (lenght > 0)
+                if (length > 0)
                 {
-                    var item = readOnlySpan.Slice(i - lenght, lenght).ToString();
+                    var item = readOnlySpan.Slice(i - length, length).ToString();
 
                     var val = FloatUtil.Parse(item);
                     data.Add(val);
                 }
 
-                lenght = 0;
+                length = 0;
             }
             return data.ToArray();
         }

--- a/CodeWalker.Core/Utils/Xml.cs
+++ b/CodeWalker.Core/Utils/Xml.cs
@@ -211,16 +211,28 @@ namespace CodeWalker
         {
             if (node == null) return new byte[0];
             var data = new List<byte>();
-            var split = Regex.Split(node.InnerText, @"[\s\r\n\t]");
-            for (int i = 0; i < split.Length; i++)
+            ReadOnlySpan<char> readOnlySpan = node.InnerText.AsSpan();
+
+            int lenght = 0;
+            for (int i = 0; i < readOnlySpan.Length; i++)
             {
-                if (!string.IsNullOrEmpty(split[i]))
+                char singleChar = readOnlySpan[i];
+
+                if (!char.IsWhiteSpace(singleChar))
                 {
-                    var str = split[i];
-                    if (string.IsNullOrEmpty(str)) continue;
-                    var val = Convert.ToByte(str, fromBase);
+                    lenght++;
+                    continue;
+                }
+
+                if (lenght > 0)
+                {
+                    var item = readOnlySpan.Slice(i - lenght, lenght).ToString();
+
+                    var val = Convert.ToByte(item, fromBase);
                     data.Add(val);
                 }
+
+                lenght = 0;
             }
             return data.ToArray();
         }
@@ -281,17 +293,28 @@ namespace CodeWalker
         {
             if (node == null) return new uint[0];
             var data = new List<uint>();
-            var split = Regex.Split(node.InnerText, @"[\s\r\n\t]");
-            for (int i = 0; i < split.Length; i++)
+            ReadOnlySpan<char> readOnlySpan = node.InnerText.AsSpan();
+
+            int lenght = 0;
+            for (int i = 0; i < readOnlySpan.Length; i++)
             {
-                if (!string.IsNullOrEmpty(split[i]))
+                char singleChar = readOnlySpan[i];
+
+                if (!char.IsWhiteSpace(singleChar))
                 {
-                    var str = split[i];
-                    if (string.IsNullOrEmpty(str)) continue;
-                    var val = 0u;
-                    uint.TryParse(str, out val);
-                    data.Add(val);
+                    lenght++;
+                    continue;
                 }
+
+                if (lenght > 0)
+                {
+                    var item = readOnlySpan.Slice(i - lenght, lenght).ToString();
+
+                    if (uint.TryParse(item, out uint val))
+                        data.Add(val);
+                }
+
+                lenght = 0;
             }
             return data.ToArray();
         }
@@ -311,17 +334,28 @@ namespace CodeWalker
         {
             if (node == null) return new int[0];
             var data = new List<int>();
-            var split = Regex.Split(node.InnerText, @"[\s\r\n\t]");
-            for (int i = 0; i < split.Length; i++)
+            ReadOnlySpan<char> readOnlySpan = node.InnerText.AsSpan();
+
+            int lenght = 0;
+            for (int i = 0; i < readOnlySpan.Length; i++)
             {
-                if (!string.IsNullOrEmpty(split[i]))
+                char singleChar = readOnlySpan[i];
+
+                if (!char.IsWhiteSpace(singleChar))
                 {
-                    var str = split[i];
-                    if (string.IsNullOrEmpty(str)) continue;
-                    var val = 0;
-                    int.TryParse(str, out val);
-                    data.Add(val);
+                    lenght++;
+                    continue;
                 }
+
+                if (lenght > 0)
+                {
+                    var item = readOnlySpan.Slice(i - lenght, lenght).ToString();
+
+                    if (int.TryParse(item, out int val))
+                        data.Add(val);
+                }
+
+                lenght = 0;
             }
             return data.ToArray();
         }
@@ -340,16 +374,31 @@ namespace CodeWalker
         public static float[] GetRawFloatArray(XmlNode node)
         {
             if (node == null) return new float[0];
-            var items = new List<float>();
-            var split = Regex.Split(node.InnerText, @"[\s\r\n\t]");//node.InnerText.Split('\n');// 
-            for (int i = 0; i < split.Length; i++)
+            var data = new List<float>();
+            ReadOnlySpan<char> readOnlySpan = node.InnerText.AsSpan();
+
+            int lenght = 0;
+            for (int i = 0; i < readOnlySpan.Length; i++)
             {
-                var s = split[i]?.Trim();
-                if (string.IsNullOrEmpty(s)) continue;
-                var f = FloatUtil.Parse(s);
-                items.Add(f);
+                char singleChar = readOnlySpan[i];
+
+                if (!char.IsWhiteSpace(singleChar))
+                {
+                    lenght++;
+                    continue;
+                }
+
+                if (lenght > 0)
+                {
+                    var item = readOnlySpan.Slice(i - lenght, lenght).ToString();
+
+                    var val = FloatUtil.Parse(item);
+                    data.Add(val);
+                }
+
+                lenght = 0;
             }
-            return items.ToArray();
+            return data.ToArray();
         }
         public static float[] GetChildRawFloatArray(XmlNode node, string name)
         {


### PR DESCRIPTION
An attempt to speedup parsing of xml, I'm using the new Span<T> to parse the node Innertext avoiding multiple allocations. This already improved a lot parsing of IndexBuffer, I expect more gain from parsing VertexBuffer.

Note: The PR adds a dependency to `System.Memory` nuget, this is temporary as it's only required on .NET Framework 4.8 or .NET Standard < 2.1, once ported to .NET (Core) 3.x/5.0 the nuget reference won't be necessary

This PR is still a draft.