### PR TITLE
Cayo Perico: Load mph4_gtxd.ymt

### DIFF
--- a/CodeWalker.Core/GameFiles/GameFileCache.cs
+++ b/CodeWalker.Core/GameFiles/GameFileCache.cs
@@ -1114,7 +1114,7 @@ namespace CodeWalker.GameFiles
                     {
                         try
                         {
-                            if ((entry.NameLower == "gtxd.ymt") || (entry.NameLower == "gtxd.meta"))
+                            if ((entry.NameLower == "gtxd.ymt") || (entry.NameLower == "gtxd.meta") || (entry.NameLower == "mph4_gtxd.ymt"))
                             {
                                 GtxdFile ymt = RpfMan.GetFile<GtxdFile>(entry);
                                 if (ymt.TxdRelationships != null)


### PR DESCRIPTION
This change will simply load the mph4_gtxd.ymt required to correctly load all the textures each drawable of the cayo perico island needs