### PR TITLE
Fixes for traffic path node editing in world view

### DIFF
--- a/CodeWalker/World/MapSelection.cs
+++ b/CodeWalker/World/MapSelection.cs
@@ -1365,7 +1365,7 @@ namespace CodeWalker
                 }
                 foreach (var kvp in pathYnds)
                 {
-                    wf.UpdatePathYndGraphics(kvp.Key, true);
+                    wf.UpdatePathYndGraphics(kvp.Key, false);
                 }
                 foreach (var kvp in navYnvs)
                 {
@@ -1399,7 +1399,7 @@ namespace CodeWalker
             {
                 if (PathNode != null)
                 {
-                    wf.UpdatePathYndGraphics(PathNode.Ynd, true);
+                    wf.UpdatePathYndGraphics(PathNode.Ynd, false);
                 }
                 if (NavPoly != null)
                 {

--- a/CodeWalker/WorldForm.cs
+++ b/CodeWalker/WorldForm.cs
@@ -1860,6 +1860,7 @@ namespace CodeWalker
             }
             else
             {
+                ynd.UpdateAllNodePositions();
                 space.BuildYndVerts(ynd);
             }
             //lock (Renderer.RenderSyncRoot)
@@ -5871,7 +5872,16 @@ namespace CodeWalker
                             GrabbedWidget.IsDragging = true;
                             if (Input.ShiftPressed)
                             {
-                                CloneItem();
+                                var ms = CurrentMapSelection.MultipleSelectionItems;
+                                if (ms?.Length > 0 && ms[0].PathNode != null)
+                                {
+                                    MessageBox.Show("You cannot clone multiple path nodes at once", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                                    GrabbedWidget.IsDragging = false;
+                                    GrabbedWidget = null;
+                                } else
+                                {
+                                    CloneItem();
+                                }
                             }
                             MarkUndoStart(GrabbedWidget);
                         }


### PR DESCRIPTION
 - Fix Shift+Click+Drag to copy nodes, without breaking links
 - Update node vertex box rendering on drag, including in multi-select mode (previously broken)
 - Block drag-copy when multiple path nodes are selected (it doesn't work, only copies the first node)
 - Clamp moved nodes to bounds of the area they are in