### PR TITLE
Add selection modes for water calming and wave quads

### DIFF
--- a/CodeWalker/Project/ProjectForm.cs
+++ b/CodeWalker/Project/ProjectForm.cs
@@ -7244,7 +7244,7 @@ namespace CodeWalker.Project
 
 
         }
-        public void GetVisibleWaterQuads(Camera camera, List<WaterQuad> quads)
+        public void GetVisibleWaterQuads<T>(Camera camera, List<T> quads) where T : BaseWaterQuad
         {
             if (hidegtavmap)
             {

--- a/CodeWalker/Rendering/Renderable.cs
+++ b/CodeWalker/Rendering/Renderable.cs
@@ -1767,16 +1767,16 @@ namespace CodeWalker.Rendering
 
             VertexCount = 4;
             Vertices = new VertexTypePCT[4];
-            Vertices[0].Position = new Vector3(key.minX, key.minY, key.z);
+            Vertices[0].Position = new Vector3(key.minX, key.minY, key.z.Value);
             Vertices[0].Texcoord = new Vector2(0.0f, 0.0f);
             Vertices[0].Colour = (uint)new Color4(key.a1 / 255.0f).ToRgba();
-            Vertices[1].Position = new Vector3(key.maxX, key.minY, key.z);
+            Vertices[1].Position = new Vector3(key.maxX, key.minY, key.z.Value);
             Vertices[1].Texcoord = new Vector2(sx, 0.0f);
             Vertices[1].Colour = (uint)new Color4(key.a2 / 255.0f).ToRgba();
-            Vertices[2].Position = new Vector3(key.minX, key.maxY, key.z);
+            Vertices[2].Position = new Vector3(key.minX, key.maxY, key.z.Value);
             Vertices[2].Texcoord = new Vector2(0.0f, sy);
             Vertices[2].Colour = (uint)new Color4(key.a3 / 255.0f).ToRgba();
-            Vertices[3].Position = new Vector3(key.maxX, key.maxY, key.z);
+            Vertices[3].Position = new Vector3(key.maxX, key.maxY, key.z.Value);
             Vertices[3].Texcoord = new Vector2(sx, sy);
             Vertices[3].Colour = (uint)new Color4(key.a4 / 255.0f).ToRgba();
 

--- a/CodeWalker/Rendering/Renderer.cs
+++ b/CodeWalker/Rendering/Renderer.cs
@@ -1242,6 +1242,8 @@ namespace CodeWalker.Rendering
             {
                 case MapSelectionMode.NavMesh:
                 case MapSelectionMode.WaterQuad:
+                case MapSelectionMode.CalmingQuad:
+                case MapSelectionMode.WaveQuad:
                 case MapSelectionMode.MloInstance:
                     clip = false;
                     break;
@@ -1326,6 +1328,8 @@ namespace CodeWalker.Rendering
             switch (mode)
             {
                 case MapSelectionMode.WaterQuad:
+                case MapSelectionMode.CalmingQuad:
+                case MapSelectionMode.WaveQuad:
                 case MapSelectionMode.MloInstance:
                     clip = false;
                     break;

--- a/CodeWalker/World/MapSelection.cs
+++ b/CodeWalker/World/MapSelection.cs
@@ -36,6 +36,8 @@ namespace CodeWalker
         Watermap = 17,
         Audio = 18,
         Occlusion = 19,
+        CalmingQuad = 20,
+        WaveQuad = 21,
     }
 
 
@@ -58,6 +60,8 @@ namespace CodeWalker
         public YmapEntityDef MloEntityDef { get; set; }
         public MCMloRoomDef MloRoomDef { get; set; }
         public WaterQuad WaterQuad { get; set; }
+        public WaterCalmingQuad CalmingQuad { get; set; }
+        public WaterWaveQuad WaveQuad { get; set; }
         public Bounds CollisionBounds { get; set; }
         public BoundPolygon CollisionPoly { get; set; }
         public BoundVertex CollisionVertex { get; set; }
@@ -100,6 +104,8 @@ namespace CodeWalker
                     (CarGenerator != null) ||
                     (GrassBatch != null) ||
                     (WaterQuad != null) ||
+                    (CalmingQuad != null) ||
+                    (WaveQuad != null) ||
                     (CollisionBounds != null) ||
                     (CollisionPoly != null) ||
                     (CollisionVertex != null) ||
@@ -139,6 +145,8 @@ namespace CodeWalker
                 || (BoxOccluder != mhit.BoxOccluder)
                 || (OccludeModelTri != mhit.OccludeModelTri)
                 || (WaterQuad != mhit.WaterQuad)
+                || (CalmingQuad != mhit.CalmingQuad)
+                || (WaveQuad != mhit.WaveQuad)
                 || (CollisionBounds != mhit.CollisionBounds)
                 || (CollisionPoly != mhit.CollisionPoly)
                 || (CollisionVertex != mhit.CollisionVertex)
@@ -166,6 +174,8 @@ namespace CodeWalker
                 || (BoxOccluder != null)
                 || (OccludeModelTri != null)
                 || (WaterQuad != null)
+                || (CalmingQuad != null)
+                || (WaveQuad != null)
                 || (CollisionBounds != null)
                 || (CollisionPoly != null)
                 || (CollisionVertex != null)
@@ -195,6 +205,8 @@ namespace CodeWalker
             BoxOccluder = null;
             OccludeModelTri = null;
             WaterQuad = null;
+            CalmingQuad = null;
+            WaveQuad = null;
             CollisionBounds = null;
             CollisionPoly = null;
             CollisionVertex = null;
@@ -276,6 +288,14 @@ namespace CodeWalker
             else if (WaterQuad != null)
             {
                 name = "WaterQuad " + WaterQuad.ToString();
+            }
+            else if (CalmingQuad != null)
+            {
+                name = "WaterCalmingQuad " + CalmingQuad.ToString();
+            }
+            else if (WaveQuad != null)
+            {
+                name = "WaterWaveQuad " + WaveQuad.ToString();
             }
             else if (NavPoly != null)
             {

--- a/CodeWalker/World/WorldInfoForm.cs
+++ b/CodeWalker/World/WorldInfoForm.cs
@@ -129,6 +129,16 @@ namespace CodeWalker.World
                 SelectionEntityTabPage.Text = "Water Quad";
                 SelEntityPropertyGrid.SelectedObject = item.WaterQuad;
             }
+            else if (item.CalmingQuad != null)
+            {
+                SelectionEntityTabPage.Text = "Water Calming Quad";
+                SelEntityPropertyGrid.SelectedObject = item.CalmingQuad;
+            }
+            else if (item.WaveQuad != null)
+            {
+                SelectionEntityTabPage.Text = "Water Wave Quad";
+                SelEntityPropertyGrid.SelectedObject = item.WaveQuad;
+            }
             else if (item.NavPoly != null)
             {
                 SelectionEntityTabPage.Text = "Nav Poly";

--- a/CodeWalker/WorldForm.Designer.cs
+++ b/CodeWalker/WorldForm.Designer.cs
@@ -312,6 +312,8 @@ namespace CodeWalker
             this.ToolbarPanel = new System.Windows.Forms.Panel();
             this.SubtitleLabel = new System.Windows.Forms.Label();
             this.SubtitleTimer = new System.Windows.Forms.Timer(this.components);
+            this.ToolbarSelectCalmingQuadButton = new System.Windows.Forms.ToolStripMenuItem();
+            this.ToolbarSelectWaveQuadButton = new System.Windows.Forms.ToolStripMenuItem();
             this.StatusStrip.SuspendLayout();
             this.ToolsPanel.SuspendLayout();
             this.ToolsTabControl.SuspendLayout();
@@ -1084,6 +1086,8 @@ namespace CodeWalker
             "Car Generator",
             "Grass",
             "Water Quad",
+            "Water Calming Quad",
+            "Water Wave Quad",
             "Collision",
             "Nav Mesh",
             "Path",
@@ -3080,6 +3084,8 @@ namespace CodeWalker
             this.ToolbarSelectCarGeneratorButton,
             this.ToolbarSelectGrassButton,
             this.ToolbarSelectWaterQuadButton,
+            this.ToolbarSelectCalmingQuadButton,
+            this.ToolbarSelectWaveQuadButton,
             this.ToolbarSelectCollisionButton,
             this.ToolbarSelectNavMeshButton,
             this.ToolbarSelectPathButton,
@@ -3604,6 +3610,20 @@ namespace CodeWalker
             // 
             this.SubtitleTimer.Tick += new System.EventHandler(this.SubtitleTimer_Tick);
             // 
+            // ToolbarSelectCalmingQuadButton
+            // 
+            this.ToolbarSelectCalmingQuadButton.Name = "ToolbarSelectCalmingQuadButton";
+            this.ToolbarSelectCalmingQuadButton.Size = new System.Drawing.Size(185, 22);
+            this.ToolbarSelectCalmingQuadButton.Text = "Water Calming Quad";
+            this.ToolbarSelectCalmingQuadButton.Click += new System.EventHandler(this.ToolbarSelectCalmingQuadButton_Click);
+            // 
+            // ToolbarSelectWaveQuadButton
+            // 
+            this.ToolbarSelectWaveQuadButton.Name = "ToolbarSelectWaveQuadButton";
+            this.ToolbarSelectWaveQuadButton.Size = new System.Drawing.Size(185, 22);
+            this.ToolbarSelectWaveQuadButton.Text = "Water Wave Quad";
+            this.ToolbarSelectWaveQuadButton.Click += new System.EventHandler(this.ToolbarSelectWaveQuadButton_Click);
+            // 
             // WorldForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -3975,5 +3995,7 @@ namespace CodeWalker
         private System.Windows.Forms.ToolStripMenuItem ToolbarRotationSnapping90Button;
         private System.Windows.Forms.ToolStripMenuItem ToolbarSnapGridSizeButton;
         private System.Windows.Forms.CheckBox HDLightsCheckBox;
+        private System.Windows.Forms.ToolStripMenuItem ToolbarSelectCalmingQuadButton;
+        private System.Windows.Forms.ToolStripMenuItem ToolbarSelectWaveQuadButton;
     }
 }

--- a/CodeWalker/WorldForm.cs
+++ b/CodeWalker/WorldForm.cs
@@ -127,7 +127,6 @@ namespace CodeWalker
         List<YndFile> renderpathynds = new List<YndFile>();
 
         bool renderwaterquads = true;
-        List<WaterQuad> renderwaterquadlist = new List<WaterQuad>();
 
         bool rendertraintracks = false;
         List<TrainTrack> rendertraintracklist = new List<TrainTrack>();
@@ -710,6 +709,14 @@ namespace CodeWalker
             {
                 RenderWorldWaterQuads();
             }
+            if (SelectionMode == MapSelectionMode.WaveQuad)
+            {
+                RenderWorldWaterWaveQuads();
+            }
+            if (SelectionMode == MapSelectionMode.CalmingQuad)
+            {
+                RenderWorldWaterCalmingQuads();
+            }
             if (rendercollisionmeshes || (SelectionMode == MapSelectionMode.Collision))
             {
                 RenderWorldCollisionMeshes();
@@ -804,19 +811,23 @@ namespace CodeWalker
 
         private void RenderWorldWaterQuads()
         {
-            renderwaterquadlist.Clear();
+            var quads = RenderWorldBaseWaterQuads(water.WaterQuads, MapSelectionMode.WaterQuad);
+            Renderer.RenderWaterQuads(quads);
+        }
 
-            water.GetVisibleQuads(camera, renderwaterquadlist);
+        private void RenderWorldWaterCalmingQuads() => RenderWorldBaseWaterQuads(water.CalmingQuads, MapSelectionMode.CalmingQuad);
 
-            if (ProjectForm != null)
-            {
-                ProjectForm.GetVisibleWaterQuads(camera, renderwaterquadlist);
-            }
+        private void RenderWorldWaterWaveQuads() => RenderWorldBaseWaterQuads(water.WaveQuads, MapSelectionMode.WaveQuad);
 
-            Renderer.RenderWaterQuads(renderwaterquadlist);
+        private List<T> RenderWorldBaseWaterQuads<T>(IEnumerable<T> quads, MapSelectionMode requiredMode) where T : BaseWaterQuad
+        {
+            List<T> renderwaterquadlist = water.GetVisibleQuads<T>(camera, quads);
 
-            UpdateMouseHits(renderwaterquadlist);
+            ProjectForm?.GetVisibleWaterQuads<T>(camera, renderwaterquadlist);
 
+            if(SelectionMode == requiredMode) UpdateMouseHits(renderwaterquadlist);
+
+            return renderwaterquadlist;
         }
 
         private void RenderWorldPaths()
@@ -1378,6 +1389,15 @@ namespace CodeWalker
 
                     Renderer.RenderCar(cg.Position, cgori, cg._CCarGen.carModel, cg._CCarGen.popGroup);
                 }
+            }
+            if (selectionItem.WaveQuad != null)
+            {
+                var quad = selectionItem.WaveQuad;
+                Vector3 quadArrowPos = new Vector3(quad.minX + (quad.maxX - quad.minX) * 0.5f, quad.minY + (quad.maxY - quad.minY) * 0.5f, 5);
+                Quaternion waveOri = quad.WaveOrientation;
+                float arrowlen = quad.Amplitude * 50;
+                float arrowrad = arrowlen * 0.066f;
+                Renderer.RenderSelectionArrowOutline(quadArrowPos, Vector3.UnitX, Vector3.UnitY, waveOri, arrowlen, arrowrad, cgrn);
             }
             if (selectionItem.LodLight != null)
             {
@@ -2900,35 +2920,42 @@ namespace CodeWalker
             }
 
         }
-        private void UpdateMouseHits(List<WaterQuad> waterquads)
+        private void UpdateMouseHits<T>(List<T> waterquads) where T : BaseWaterQuad
         {
-            if (SelectionMode != MapSelectionMode.WaterQuad) return;
-
             BoundingBox bbox = new BoundingBox();
             Ray mray = new Ray();
             mray.Position = camera.MouseRay.Position + camera.Position;
             mray.Direction = camera.MouseRay.Direction;
-            float hitdist = float.MaxValue;
+            float hitdist;
 
 
-            foreach (var quad in waterquads)
+            foreach (T quad in waterquads)
             {
                 MapBox mb = new MapBox();
                 mb.CamRelPos = -camera.Position;
-                mb.BBMin = new Vector3(quad.minX, quad.minY, quad.z);
-                mb.BBMax = new Vector3(quad.maxX, quad.maxY, quad.z);
+                mb.BBMin = new Vector3(quad.minX, quad.minY, quad.z ?? 0);
+                mb.BBMax = new Vector3(quad.maxX, quad.maxY, quad.z ?? 0);
                 mb.Orientation = Quaternion.Identity;
                 mb.Scale = Vector3.One;
                 Renderer.BoundingBoxes.Add(mb);
 
                 bbox.Minimum = mb.BBMin;
                 bbox.Maximum = mb.BBMax;
-                if (mray.Intersects(ref bbox, out hitdist) && (hitdist < CurMouseHit.HitDist) && (hitdist > 0))
+
+                if(mray.Intersects(ref bbox, out hitdist) && hitdist > 0 && hitdist <= CurMouseHit.HitDist)
                 {
-                    CurMouseHit.WaterQuad = quad;
-                    CurMouseHit.HitDist = hitdist;
-                    CurMouseHit.CamRel = mb.CamRelPos;
-                    CurMouseHit.AABB = bbox;
+                    float curSize = CurMouseHit.AABB.Size.X * CurMouseHit.AABB.Size.Y;
+                    float newSize = bbox.Size.X * bbox.Size.Y;
+                    if ((curSize == 0) || (newSize < curSize))
+                    {
+                        CurMouseHit.HitDist = hitdist;
+                        CurMouseHit.CamRel = mb.CamRelPos;
+                        CurMouseHit.AABB = bbox;
+
+                        CurMouseHit.WaterQuad = quad as WaterQuad;
+                        CurMouseHit.WaveQuad = quad as WaterWaveQuad;
+                        CurMouseHit.CalmingQuad = quad as WaterCalmingQuad;
+                    }
                 }
             }
         }
@@ -3721,6 +3748,16 @@ namespace CodeWalker
             {
                 SelectionEntityTabPage.Text = "WaterQuad";
                 SelEntityPropertyGrid.SelectedObject = item.WaterQuad;
+            }
+            else if (item.CalmingQuad != null)
+            {
+                SelectionEntityTabPage.Text = "CalmingQuad";
+                SelEntityPropertyGrid.SelectedObject = item.CalmingQuad;
+            }
+            else if (item.WaveQuad != null)
+            {
+                SelectionEntityTabPage.Text = "WaveQuad";
+                SelEntityPropertyGrid.SelectedObject = item.WaveQuad;
             }
             else if (item.PathNode != null)
             {
@@ -5551,6 +5588,14 @@ namespace CodeWalker
                     mode = MapSelectionMode.WaterQuad;
                     ToolbarSelectWaterQuadButton.Checked = true;
                     break;
+                case "Water Calming Quad":
+                    mode = MapSelectionMode.CalmingQuad;
+                    ToolbarSelectCalmingQuadButton.Checked = true;
+                    break;
+                case "Water Wave Quad":
+                    mode = MapSelectionMode.WaveQuad;
+                    ToolbarSelectWaveQuadButton.Checked = true;
+                    break;
                 case "Collision":
                     mode = MapSelectionMode.Collision;
                     ToolbarSelectCollisionButton.Checked = true;
@@ -7306,6 +7351,18 @@ namespace CodeWalker
         private void ToolbarSelectWaterQuadButton_Click(object sender, EventArgs e)
         {
             SetSelectionMode("Water Quad");
+            SetMouseSelect(true);
+        }
+
+        private void ToolbarSelectCalmingQuadButton_Click(object sender, EventArgs e)
+        {
+            SetSelectionMode("Water Calming Quad");
+            SetMouseSelect(true);
+        }
+
+        private void ToolbarSelectWaveQuadButton_Click(object sender, EventArgs e)
+        {
+            SetSelectionMode("Water Wave Quad");
             SetMouseSelect(true);
         }
 


### PR DESCRIPTION
- [x] Render quads
- [x] Add new selection modes
- [x] Add selection information
- [x] Show wave quad direction
- [x] Add toolbar buttons
- [x] Select smallest quad when there are multiple hits (to enable selecting nested quads)


Screenshot previews: 

**Water Quad selection:**

![image](https://user-images.githubusercontent.com/17376331/137095950-91432ce5-9c10-40a2-bacd-6e49e343cc98.png)

**Calming Quad selection:**

![image](https://user-images.githubusercontent.com/17376331/137096114-5cf16df0-45ae-40f6-b0aa-4ec0d4b78354.png)

**Wave Quad selection:**

![image](https://user-images.githubusercontent.com/17376331/137096267-5ef215bd-69c2-4b9c-b69a-3aa57a16ebca.png)

**Toolbar buttons:**

![image](https://user-images.githubusercontent.com/17376331/137097727-307d7988-c516-41bf-a759-c7a8a6f37b24.png)
