### PR TITLE
Fix importing occlusions from .ymap files

### DIFF
--- a/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs
+++ b/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs
@@ -3309,6 +3309,7 @@ namespace CodeWalker.GameFiles
             Vertices = MetaTypes.ConvertDataArray<Vector3>(Data, 0, vertexCount);
             Indices = new byte[indexCount];
             Buffer.BlockCopy(Data, indicesOffset, Indices, 0, indexCount);
+            BuildTriangles();
         }
 
 


### PR DESCRIPTION
Occlude Models from imported .ymap files was not being recognized properly.
The triangles count being shown on Project window was always being 0.

Triangles before the fix:
![cw bug](https://user-images.githubusercontent.com/35692178/196322356-71490d04-c1a0-4337-94a3-206714679b93.png)

Triangles after:
![cw fix](https://user-images.githubusercontent.com/35692178/196322703-0d41722a-892f-437b-8ebf-60d8cff2e415.png)

I already tested this fix and i hope there's no regression in some unexpected scenario.