### PR TITLE
Fix decimal point being removed in BSRadius input

### DIFF
--- a/CodeWalker/Project/Panels/EditYtypArchetypePanel.cs
+++ b/CodeWalker/Project/Panels/EditYtypArchetypePanel.cs
@@ -57,7 +57,7 @@ namespace CodeWalker.Project.Panels
                 BBMinTextBox.Text = FloatUtil.GetVector3String(CurrentArchetype._BaseArchetypeDef.bbMin);
                 BBMaxTextBox.Text = FloatUtil.GetVector3String(CurrentArchetype._BaseArchetypeDef.bbMax);
                 BSCenterTextBox.Text = FloatUtil.GetVector3String(CurrentArchetype._BaseArchetypeDef.bsCentre);
-                BSRadiusTextBox.Text = FloatUtil.ToString(CurrentArchetype._BaseArchetypeDef.bsRadius);
+                BSRadiusTextBox.Text = CurrentArchetype._BaseArchetypeDef.bsRadius.ToString();
 
                 if (CurrentArchetype is MloArchetype MloArchetype)
                 {


### PR DESCRIPTION
Currently, when you click away from an archetype and click back, the decimal point is being removed causing an incorrect BSRadius.
Not sure if this is a good fix as I am not that familiar with C#.

Before:
![before](https://user-images.githubusercontent.com/30494798/228332098-23a638c4-53e2-4d71-a16c-746ec737d24a.gif)

After:
![after](https://user-images.githubusercontent.com/30494798/228332165-edb2c6d9-ffdc-426d-a3b6-3a3b88b7d9a3.gif)

