### PR TITLE
Fix incorrect rendering of BoundGeometry and BoundDisc 

### DIFF
--- a/CodeWalker/Rendering/Renderable.cs
+++ b/CodeWalker/Rendering/Renderable.cs
@@ -2301,14 +2301,14 @@ namespace CodeWalker.Rendering
         }
         public void Init(BoundDisc bdisc, ref Matrix xform)
         {
-            Matrix rmat = xform;
+            Matrix rmat = Matrix.RotationZ((float)Math.PI / 2) * xform;
             rmat.TranslationVector = Vector3.Zero;
 
             Bound = bdisc;
             BBMin = bdisc.BoxMin;
             BBMax = bdisc.BoxMax;
             BBOffset = xform.TranslationVector;
-            BBOrientation = Quaternion.LookAtLH(Vector3.Zero, Vector3.UnitX, Vector3.UnitZ) * Quaternion.RotationMatrix(rmat);
+            BBOrientation = Quaternion.RotationMatrix(rmat);
 
             var mat = (BoundsMaterialType)bdisc.MaterialIndex;
             var colourf = BoundsMaterialTypes.GetMaterialColour(mat);
@@ -2316,7 +2316,7 @@ namespace CodeWalker.Rendering
 
             var rcyl = new RenderableCylinder();
             rcyl.Colour = colour;
-            rcyl.Point1 = Vector3.TransformCoordinate(bdisc.SphereCenter - new Vector3(bdisc.Margin, 0, 0), xform);
+            rcyl.Point1 = Vector3.TransformCoordinate(bdisc.SphereCenter + new Vector3(bdisc.Margin, 0, 0), xform);
             rcyl.Orientation = BBOrientation;
             rcyl.Length = bdisc.Margin * 2.0f;
             rcyl.Radius = bdisc.SphereRadius;

--- a/CodeWalker/Rendering/Renderable.cs
+++ b/CodeWalker/Rendering/Renderable.cs
@@ -2109,9 +2109,9 @@ namespace CodeWalker.Rendering
                 {
                     case BoundPolygonType.Triangle:
                         var ptri = poly as BoundPolygonTriangle;
-                        p1 = bgeom.GetVertex(ptri.vertIndex1);
-                        p2 = bgeom.GetVertex(ptri.vertIndex2);
-                        p3 = bgeom.GetVertex(ptri.vertIndex3);
+                        p1 = bgeom.GetVertexPos(ptri.vertIndex1);
+                        p2 = bgeom.GetVertexPos(ptri.vertIndex2);
+                        p3 = bgeom.GetVertexPos(ptri.vertIndex3);
                         n1 = Vector3.Normalize(Vector3.Cross(p2 - p1, p3 - p1));
                         AddVertex(p1, n1, colour, rverts, ref curvert);
                         AddVertex(p2, n1, colour, rverts, ref curvert);
@@ -2119,15 +2119,15 @@ namespace CodeWalker.Rendering
                         break;
                     case BoundPolygonType.Sphere:
                         var psph = poly as BoundPolygonSphere;
-                        rspheres[cursphere].Center = bgeom.GetVertex(psph.sphereIndex);
+                        rspheres[cursphere].Center = bgeom.GetVertexPos(psph.sphereIndex);
                         rspheres[cursphere].Radius = psph.sphereRadius;// * 0.5f;//diameter?
                         rspheres[cursphere].Colour = colour;
                         cursphere++;
                         break;
                     case BoundPolygonType.Capsule:
                         var bcap = poly as BoundPolygonCapsule;
-                        p1 = bgeom.GetVertex(bcap.capsuleIndex1);
-                        p2 = bgeom.GetVertex(bcap.capsuleIndex2);
+                        p1 = bgeom.GetVertexPos(bcap.capsuleIndex1);
+                        p2 = bgeom.GetVertexPos(bcap.capsuleIndex2);
                         a1 = p2 - p1;
                         n1 = Vector3.Normalize(a1);
                         p3 = Vector3.Normalize(n1.GetPerpVec());
@@ -2142,10 +2142,10 @@ namespace CodeWalker.Rendering
                         break;
                     case BoundPolygonType.Box:  //(...only 4 inds... = diagonal corners)
                         var pbox = poly as BoundPolygonBox;
-                        p1 = bgeom.GetVertex(pbox.boxIndex1);
-                        p2 = bgeom.GetVertex(pbox.boxIndex2);
-                        p3 = bgeom.GetVertex(pbox.boxIndex3);
-                        p4 = bgeom.GetVertex(pbox.boxIndex4);
+                        p1 = bgeom.GetVertexPos(pbox.boxIndex1);
+                        p2 = bgeom.GetVertexPos(pbox.boxIndex2);
+                        p3 = bgeom.GetVertexPos(pbox.boxIndex3);
+                        p4 = bgeom.GetVertexPos(pbox.boxIndex4);
                         a1 = ((p3 + p4) - (p1 + p2)) * 0.5f;
                         p2 = p1 + a1;
                         p3 = p3 - a1;
@@ -2159,8 +2159,8 @@ namespace CodeWalker.Rendering
                         break;
                     case BoundPolygonType.Cylinder:
                         var pcyl = poly as BoundPolygonCylinder;
-                        p1 = bgeom.GetVertex(pcyl.cylinderIndex1);
-                        p2 = bgeom.GetVertex(pcyl.cylinderIndex2);
+                        p1 = bgeom.GetVertexPos(pcyl.cylinderIndex1);
+                        p2 = bgeom.GetVertexPos(pcyl.cylinderIndex2);
                         a1 = p2 - p1;
                         n1 = Vector3.Normalize(a1);
                         p3 = Vector3.Normalize(n1.GetPerpVec());

--- a/CodeWalker/Rendering/Renderer.cs
+++ b/CodeWalker/Rendering/Renderer.cs
@@ -3616,21 +3616,10 @@ namespace CodeWalker.Rendering
                     {
                         if (geom == null) continue;
                         rbginst.Geom = geom;
-                        
-                        var pos = position;
-                        var ori = orientation;
-                        var sca = scale;
-                        if (geom.Bound is BoundGeometry bgeom)
-                        {
-                            var rmat = bgeom.Transform;
-                            sca = scale * rmat.ScaleVector;
-                            pos = position + orientation.Multiply(rmat.TranslationVector);
-                            rmat.TranslationVector = Vector3.Zero;
-                            ori = orientation * Quaternion.RotationMatrix(rmat);
-                        }
-                        rbginst.Inst.Position = pos + ori.Multiply(geom.CenterGeom * sca);
-                        rbginst.Inst.Orientation = ori;
-                        rbginst.Inst.Scale = sca;
+
+                        rbginst.Inst.Position = position;
+                        rbginst.Inst.Scale = scale;
+                        rbginst.Inst.Orientation = orientation;
                         rbginst.Inst.CamRel = rbginst.Inst.Position - camera.Position;
                         shaders.Enqueue(ref rbginst);
                     }


### PR DESCRIPTION
In some cases, depending on the value of CompositeTransforms, BoundGeometry or BoundDisc would not render properly. For some reason, I never found this to be the case for vanilla yfts/ybns, only modified or custom ones.

I've been trying to get collisions to export properly with world transformations in Blender but kept running into roadblocks because the BoundDiscs and BoundGeometrys seemed off when previewing in the RPF explorer. However, when importing back into Blender, it looked as expected. I also saw no issues when previewing the same Sollumz-exported file in OpenIV.