### PR TITLE
Correctly calculate BVH item extents

### DIFF
--- a/CodeWalker.Core/GameFiles/Resources/Bounds.cs
+++ b/CodeWalker.Core/GameFiles/Resources/Bounds.cs
@@ -2779,7 +2779,7 @@ namespace CodeWalker.GameFiles
                 if (child != null)
                 {
                     var cbox = new BoundingBox(child.BoxMin, child.BoxMax);
-                    var tcbox = cbox.Transform(child.Position, child.Orientation, child.Scale);
+                    var tcbox = cbox.Transform(child.Transform);
                     var it = new BVHBuilderItem();
                     it.Min = tcbox.Minimum;
                     it.Max = tcbox.Maximum;
@@ -2793,16 +2793,7 @@ namespace CodeWalker.GameFiles
                 }
             }
 
-            var bvh = BVHBuilder.Build(items, 1); //composites have BVH item threshold of 1
-
-            BoxMin = bvh.BoundingBoxMin.XYZ();
-            BoxMax = bvh.BoundingBoxMax.XYZ();
-            BoxCenter = bvh.BoundingBoxCenter.XYZ();
-            SphereCenter = BoxCenter;
-            SphereRadius = (BoxMax - BoxCenter).Length();
-
-            BVH = bvh;
-
+            BVH = BVHBuilder.Build(items, 1); //composites have BVH item threshold of 1
         }
 
         public void UpdateChildrenFlags()

--- a/CodeWalker.Core/Utils/Vectors.cs
+++ b/CodeWalker.Core/Utils/Vectors.cs
@@ -127,6 +127,11 @@ namespace CodeWalker
         public static BoundingBox Transform(this BoundingBox b, Vector3 position, Quaternion orientation, Vector3 scale)
         {
             var mat = Matrix.Transformation(Vector3.Zero, Quaternion.Identity, scale, Vector3.Zero, orientation, position);
+            return b.Transform(mat);
+        }
+
+        public static BoundingBox Transform(this BoundingBox b, Matrix mat)
+        {
             var matabs = mat;
             matabs.Column1 = mat.Column1.Abs();
             matabs.Column2 = mat.Column2.Abs();


### PR DESCRIPTION
The bounding box calculations for Composite BVH items were incorrect which was causing a lot of issues for certain collisions. For example, prop_gas_tank_01a.yft would not react to certain weapons and the character's head could clip through it in certain spots. 
 
These calculations have been tested with the original files and are exactly the same in 99.98% of files. In the remaining 0.02% of files, the error is usually only about 0.1 or 0.01 give or take.