### PR TITLE
Order clips in ycd files alphabetically to improve readability

### DIFF
--- a/CodeWalker/Forms/YcdForm.cs
+++ b/CodeWalker/Forms/YcdForm.cs
@@ -138,7 +138,7 @@ namespace CodeWalker.Forms
 
             if (ycd?.ClipMapEntries != null)
             {
-                foreach (var cme in ycd.ClipMapEntries)
+                foreach (var cme in ycd.ClipMapEntries.OrderBy(x => x.Clip?.ShortName ?? x.Hash.ToString())
                 {
                     if (cme != null)
                     {


### PR DESCRIPTION
Immensely nice QOL feature for synched scenes, as shown below

![image](https://github.com/dexyfex/CodeWalker/assets/28872095/6b135f02-39c1-4f03-86d7-1d824c27d3d0)
