### PR TITLE
Escape ClipBase.Hash when writing XML

### DIFF
--- a/CodeWalker.Core/GameFiles/Resources/Clip.cs
+++ b/CodeWalker.Core/GameFiles/Resources/Clip.cs
@@ -3151,7 +3151,7 @@ namespace CodeWalker.GameFiles
 
         public virtual void WriteXml(StringBuilder sb, int indent)
         {
-            YcdXml.StringTag(sb, indent, "Hash", YcdXml.HashString(Hash));
+            YcdXml.StringTag(sb, indent, "Hash", MetaXml.XmlEscape(YcdXml.HashString(Hash)));
             YcdXml.StringTag(sb, indent, "Name", MetaXml.XmlEscape(Name));
             YcdXml.ValueTag(sb, indent, "Type", Type.ToString());
             YcdXml.ValueTag(sb, indent, "Unknown30", Unknown_30h.ToString());


### PR DESCRIPTION
Some YCDs have special characters in the clip hash, which causes the XML to be invalid.

missarmenian2.ycd
![missarmenian2.ycd](https://github.com/dexyfex/CodeWalker/assets/12873137/35fcd567-85ea-4fc0-a48b-ceceb37312c7)

missfinale_a_ig_2.ycd
![missfinale_a_ig_2.ycd](https://github.com/dexyfex/CodeWalker/assets/12873137/321edcad-1770-4df1-9fba-4c8e8dde192b)
