### PR TITLE
Use path relative to executable to load shaders and icons

### DIFF
--- a/CodeWalker/CodeWalker - Backup.csproj
+++ b/CodeWalker/CodeWalker - Backup.csproj
@@ -1,0 +1,55 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net48</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <UseWPF>true</UseWPF>
+    <ApplicationIcon>CW.ico</ApplicationIcon>
+    <Copyright>dexyfex</Copyright>
+    <Company>dexyfex software</Company>
+    <Authors>dexyfex</Authors>
+	<LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DockPanelSuite.ThemeVS2015" Version="3.0.6" />
+    <PackageReference Include="FCTB" Version="2.16.24" />
+    <PackageReference Include="SharpDX" Version="4.2.0" />
+    <PackageReference Include="SharpDX.D3DCompiler" Version="4.2.0" />
+    <PackageReference Include="SharpDX.Direct2D1" Version="4.2.0" />
+    <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />
+    <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
+    <PackageReference Include="SharpDX.XAudio2" Version="4.2.0" />
+    <PackageReference Include="SharpDX.XInput" Version="4.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CodeWalker.Core\CodeWalker.Core.csproj" />
+    <ProjectReference Include="..\CodeWalker.WinForms\CodeWalker.WinForms.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Windows.Forms.DataVisualization" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Properties\Settings.Designer.cs">
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Properties\Settings.settings">
+      <Generator>PublicSettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/CodeWalker/Rendering/Shaders/BasicShader.cs
+++ b/CodeWalker/Rendering/Shaders/BasicShader.cs
@@ -12,6 +12,7 @@ using MapFlags = SharpDX.Direct3D11.MapFlags;
 using SharpDX;
 using CodeWalker.GameFiles;
 using CodeWalker.World;
+using System.Diagnostics;
 
 namespace CodeWalker.Rendering
 {
@@ -184,34 +185,35 @@ namespace CodeWalker.Rendering
 
         public BasicShader(Device device)
         {
-            byte[] vspnctbytes = File.ReadAllBytes("Shaders\\BasicVS_PNCT.cso");
-            byte[] vspncttbytes = File.ReadAllBytes("Shaders\\BasicVS_PNCTT.cso");
-            byte[] vspnctttbytes = File.ReadAllBytes("Shaders\\BasicVS_PNCTTT.cso");
-            byte[] vspncctbytes = File.ReadAllBytes("Shaders\\BasicVS_PNCCT.cso");
-            byte[] vspnccttbytes = File.ReadAllBytes("Shaders\\BasicVS_PNCCTT.cso");
-            byte[] vspncctttbytes = File.ReadAllBytes("Shaders\\BasicVS_PNCCTTT.cso");
-            byte[] vspnctxbytes = File.ReadAllBytes("Shaders\\BasicVS_PNCTX.cso");
-            byte[] vspncctxbytes = File.ReadAllBytes("Shaders\\BasicVS_PNCCTX.cso");
-            byte[] vspncttxbytes = File.ReadAllBytes("Shaders\\BasicVS_PNCTTX.cso");
-            byte[] vspnccttxbytes = File.ReadAllBytes("Shaders\\BasicVS_PNCCTTX.cso");
-            byte[] vspnctttxbytes = File.ReadAllBytes("Shaders\\BasicVS_PNCTTTX.cso");
-            byte[] vspncctttxbytes = File.ReadAllBytes("Shaders\\BasicVS_PNCCTTTX.cso");
+            string folder = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "Shaders");
+            byte[] vspnctbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PNCT.cso"));
+            byte[] vspncttbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PNCTT.cso"));
+            byte[] vspnctttbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PNCTTT.cso"));
+            byte[] vspncctbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PNCCT.cso"));
+            byte[] vspnccttbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PNCCTT.cso"));
+            byte[] vspncctttbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PNCCTTT.cso"));
+            byte[] vspnctxbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PNCTX.cso"));
+            byte[] vspncctxbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PNCCTX.cso"));
+            byte[] vspncttxbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PNCTTX.cso"));
+            byte[] vspnccttxbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PNCCTTX.cso"));
+            byte[] vspnctttxbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PNCTTTX.cso"));
+            byte[] vspncctttxbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PNCCTTTX.cso"));
 
-            byte[] vspbbnctbytes = File.ReadAllBytes("Shaders\\BasicVS_PBBNCT.cso");
-            byte[] vspbbnctxbytes = File.ReadAllBytes("Shaders\\BasicVS_PBBNCTX.cso");
-            byte[] vspbbncttbytes = File.ReadAllBytes("Shaders\\BasicVS_PBBNCTT.cso");
-            byte[] vspbbnctttbytes = File.ReadAllBytes("Shaders\\BasicVS_PBBNCTTT.cso");
-            byte[] vspbbncctbytes = File.ReadAllBytes("Shaders\\BasicVS_PBBNCCT.cso");
-            byte[] vspbbncctxbytes = File.ReadAllBytes("Shaders\\BasicVS_PBBNCCTX.cso");
-            byte[] vspbbnccttxbytes = File.ReadAllBytes("Shaders\\BasicVS_PBBNCCTTX.cso");
-            byte[] vspbbncttxbytes = File.ReadAllBytes("Shaders\\BasicVS_PBBNCTTX.cso");
+            byte[] vspbbnctbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PBBNCT.cso"));
+            byte[] vspbbnctxbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PBBNCTX.cso"));
+            byte[] vspbbncttbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PBBNCTT.cso"));
+            byte[] vspbbnctttbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PBBNCTTT.cso"));
+            byte[] vspbbncctbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PBBNCCT.cso"));
+            byte[] vspbbncctxbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PBBNCCTX.cso"));
+            byte[] vspbbnccttxbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PBBNCCTTX.cso"));
+            byte[] vspbbncttxbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_PBBNCTTX.cso"));
 
-            byte[] vsboxbytes = File.ReadAllBytes("Shaders\\BasicVS_Box.cso");
-            byte[] vsspherebytes = File.ReadAllBytes("Shaders\\BasicVS_Sphere.cso");
-            byte[] vscapsulebytes = File.ReadAllBytes("Shaders\\BasicVS_Capsule.cso");
-            byte[] vscylinderbytes = File.ReadAllBytes("Shaders\\BasicVS_Cylinder.cso");
-            byte[] psbytes = File.ReadAllBytes("Shaders\\BasicPS.cso");
-            byte[] psdefbytes = File.ReadAllBytes("Shaders\\BasicPS_Deferred.cso");
+            byte[] vsboxbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_Box.cso"));
+            byte[] vsspherebytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_Sphere.cso"));
+            byte[] vscapsulebytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_Capsule.cso"));
+            byte[] vscylinderbytes = File.ReadAllBytes(Path.Combine(folder, "BasicVS_Cylinder.cso"));
+            byte[] psbytes = File.ReadAllBytes(Path.Combine(folder, "BasicPS.cso"));
+            byte[] psdefbytes = File.ReadAllBytes(Path.Combine(folder, "BasicPS_Deferred.cso"));
 
             basicvspnct = new VertexShader(device, vspnctbytes);
             basicvspnctt = new VertexShader(device, vspncttbytes);

--- a/CodeWalker/Rendering/Shaders/BoundsShader.cs
+++ b/CodeWalker/Rendering/Shaders/BoundsShader.cs
@@ -12,6 +12,7 @@ using CodeWalker.GameFiles;
 using System.IO;
 using SharpDX.DXGI;
 using CodeWalker.World;
+using System.Diagnostics;
 
 namespace CodeWalker.Rendering
 {
@@ -71,9 +72,10 @@ namespace CodeWalker.Rendering
 
         public BoundsShader(Device device)
         {
-            byte[] spherevsbytes = File.ReadAllBytes("Shaders\\BoundingSphereVS.cso");
-            byte[] boxvsbytes = File.ReadAllBytes("Shaders\\BoundingBoxVS.cso");
-            byte[] psbytes = File.ReadAllBytes("Shaders\\BoundsPS.cso");
+            string folder = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "Shaders");
+            byte[] spherevsbytes = File.ReadAllBytes(Path.Combine(folder, "BoundingSphereVS.cso"));
+            byte[] boxvsbytes = File.ReadAllBytes(Path.Combine(folder, "BoundingBoxVS.cso"));
+            byte[] psbytes = File.ReadAllBytes(Path.Combine(folder, "BoundsPS.cso"));
 
             spherevs = new VertexShader(device, spherevsbytes);
             boxvs = new VertexShader(device, boxvsbytes);

--- a/CodeWalker/Rendering/Shaders/CableShader.cs
+++ b/CodeWalker/Rendering/Shaders/CableShader.cs
@@ -12,6 +12,7 @@ using MapFlags = SharpDX.Direct3D11.MapFlags;
 using SharpDX;
 using CodeWalker.GameFiles;
 using CodeWalker.World;
+using System.Diagnostics;
 
 namespace CodeWalker.Rendering
 {
@@ -88,9 +89,10 @@ namespace CodeWalker.Rendering
 
         public CableShader(Device device)
         {
-            byte[] vsbytes = File.ReadAllBytes("Shaders\\CableVS.cso");
-            byte[] psbytes = File.ReadAllBytes("Shaders\\CablePS.cso");
-            byte[] psdefbytes = File.ReadAllBytes("Shaders\\CablePS_Deferred.cso");
+            string folder = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "Shaders");
+            byte[] vsbytes = File.ReadAllBytes(Path.Combine(folder, "CableVS.cso"));
+            byte[] psbytes = File.ReadAllBytes(Path.Combine(folder, "CablePS.cso"));
+            byte[] psdefbytes = File.ReadAllBytes(Path.Combine(folder, "CablePS_Deferred.cso"));
 
             vs = new VertexShader(device, vsbytes);
             ps = new PixelShader(device, psbytes);

--- a/CodeWalker/Rendering/Shaders/CloudsShader.cs
+++ b/CodeWalker/Rendering/Shaders/CloudsShader.cs
@@ -8,6 +8,7 @@ using CodeWalker.World;
 using SharpDX.Direct3D11;
 using System.IO;
 using SharpDX;
+using System.Diagnostics;
 
 namespace CodeWalker.Rendering
 {
@@ -106,8 +107,9 @@ namespace CodeWalker.Rendering
 
         public CloudsShader(Device device)
         {
-            byte[] vsbytes = File.ReadAllBytes("Shaders\\CloudsVS.cso");
-            byte[] psbytes = File.ReadAllBytes("Shaders\\CloudsPS.cso");
+            string folder = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "Shaders");
+            byte[] vsbytes = File.ReadAllBytes(Path.Combine(folder, "CloudsVS.cso"));
+            byte[] psbytes = File.ReadAllBytes(Path.Combine(folder, "CloudsPS.cso"));
 
             vs = new VertexShader(device, vsbytes);
             ps = new PixelShader(device, psbytes);

--- a/CodeWalker/Rendering/Shaders/DeferredScene.cs
+++ b/CodeWalker/Rendering/Shaders/DeferredScene.cs
@@ -13,6 +13,7 @@ using CodeWalker.World;
 using SharpDX;
 using SharpDX.DXGI;
 using SharpDX.Mathematics.Interop;
+using System.Diagnostics;
 
 namespace CodeWalker.Rendering
 {
@@ -128,17 +129,18 @@ namespace CodeWalker.Rendering
         {
             var device = dxman.device;
 
-            byte[] bDirLightVS = File.ReadAllBytes("Shaders\\DirLightVS.cso");
-            byte[] bDirLightPS = File.ReadAllBytes("Shaders\\DirLightPS.cso");
-            byte[] bDirLightMSPS = File.ReadAllBytes("Shaders\\DirLightPS_MS.cso");
-            byte[] bLodLightVS = File.ReadAllBytes("Shaders\\LodLightsVS.cso");
-            byte[] bLodLightPS = File.ReadAllBytes("Shaders\\LodLightsPS.cso");
-            byte[] bLodLightMSPS = File.ReadAllBytes("Shaders\\LodLightsPS_MS.cso");
-            byte[] bLightVS = File.ReadAllBytes("Shaders\\LightVS.cso");
-            byte[] bLightPS = File.ReadAllBytes("Shaders\\LightPS.cso");
-            byte[] bLightMSPS = File.ReadAllBytes("Shaders\\LightPS_MS.cso");
-            byte[] bFinalVS = File.ReadAllBytes("Shaders\\PPFinalPassVS.cso");
-            byte[] bSSAAPS = File.ReadAllBytes("Shaders\\PPSSAAPS.cso");
+            string folder = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "Shaders");
+            byte[] bDirLightVS = File.ReadAllBytes(Path.Combine(folder, "DirLightVS.cso"));
+            byte[] bDirLightPS = File.ReadAllBytes(Path.Combine(folder, "DirLightPS.cso"));
+            byte[] bDirLightMSPS = File.ReadAllBytes(Path.Combine(folder, "DirLightPS_MS.cso"));
+            byte[] bLodLightVS = File.ReadAllBytes(Path.Combine(folder, "LodLightsVS.cso"));
+            byte[] bLodLightPS = File.ReadAllBytes(Path.Combine(folder, "LodLightsPS.cso"));
+            byte[] bLodLightMSPS = File.ReadAllBytes(Path.Combine(folder, "LodLightsPS_MS.cso"));
+            byte[] bLightVS = File.ReadAllBytes(Path.Combine(folder, "LightVS.cso"));
+            byte[] bLightPS = File.ReadAllBytes(Path.Combine(folder, "LightPS.cso"));
+            byte[] bLightMSPS = File.ReadAllBytes(Path.Combine(folder, "LightPS_MS.cso"));
+            byte[] bFinalVS = File.ReadAllBytes(Path.Combine(folder, "PPFinalPassVS.cso"));
+            byte[] bSSAAPS = File.ReadAllBytes(Path.Combine(folder, "PPSSAAPS.cso"));
 
             DirLightVS = new VertexShader(device, bDirLightVS);
             DirLightPS = new PixelShader(device, bDirLightPS);

--- a/CodeWalker/Rendering/Shaders/DistantLightsShader.cs
+++ b/CodeWalker/Rendering/Shaders/DistantLightsShader.cs
@@ -12,6 +12,7 @@ using Device = SharpDX.Direct3D11.Device;
 using Buffer = SharpDX.Direct3D11.Buffer;
 using MapFlags = SharpDX.Direct3D11.MapFlags;
 using CodeWalker.World;
+using System.Diagnostics;
 
 namespace CodeWalker.Rendering
 {
@@ -41,8 +42,9 @@ namespace CodeWalker.Rendering
 
         public DistantLightsShader(Device device)
         {
-            byte[] vsbytes = File.ReadAllBytes("Shaders\\DistantLightsVS.cso");
-            byte[] psbytes = File.ReadAllBytes("Shaders\\DistantLightsPS.cso");
+            string folder = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "Shaders");
+            byte[] vsbytes = File.ReadAllBytes(Path.Combine(folder, "DistantLightsVS.cso"));
+            byte[] psbytes = File.ReadAllBytes(Path.Combine(folder, "DistantLightsPS.cso"));
 
             lightsvs = new VertexShader(device, vsbytes);
             lightsps = new PixelShader(device, psbytes);

--- a/CodeWalker/Rendering/Shaders/MarkerShader.cs
+++ b/CodeWalker/Rendering/Shaders/MarkerShader.cs
@@ -12,6 +12,7 @@ using CodeWalker.GameFiles;
 using System.IO;
 using SharpDX.DXGI;
 using CodeWalker.World;
+using System.Diagnostics;
 
 namespace CodeWalker.Rendering
 {
@@ -46,8 +47,9 @@ namespace CodeWalker.Rendering
 
         public MarkerShader(Device device)
         {
-            byte[] vsbytes = File.ReadAllBytes("Shaders\\MarkerVS.cso");
-            byte[] psbytes = File.ReadAllBytes("Shaders\\MarkerPS.cso");
+            string folder = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "Shaders");
+            byte[] vsbytes = File.ReadAllBytes(Path.Combine(folder, "MarkerVS.cso"));
+            byte[] psbytes = File.ReadAllBytes(Path.Combine(folder, "MarkerPS.cso"));
 
             markervs = new VertexShader(device, vsbytes);
             markerps = new PixelShader(device, psbytes);

--- a/CodeWalker/Rendering/Shaders/PathShader.cs
+++ b/CodeWalker/Rendering/Shaders/PathShader.cs
@@ -12,6 +12,7 @@ using CodeWalker.GameFiles;
 using System.IO;
 using SharpDX.DXGI;
 using CodeWalker.World;
+using System.Diagnostics;
 
 namespace CodeWalker.Rendering
 {
@@ -46,11 +47,12 @@ namespace CodeWalker.Rendering
 
         public PathShader(Device device)
         {
-            byte[] boxvsbytes = File.ReadAllBytes("Shaders\\PathBoxVS.cso");
-            byte[] boxpsbytes = File.ReadAllBytes("Shaders\\PathBoxPS.cso");
-            byte[] dynvsbytes = File.ReadAllBytes("Shaders\\PathDynVS.cso");
-            byte[] vsbytes = File.ReadAllBytes("Shaders\\PathVS.cso");
-            byte[] psbytes = File.ReadAllBytes("Shaders\\PathPS.cso");
+            string folder = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "Shaders");
+            byte[] boxvsbytes = File.ReadAllBytes(Path.Combine(folder, "PathBoxVS.cso"));
+            byte[] boxpsbytes = File.ReadAllBytes(Path.Combine(folder, "PathBoxPS.cso"));
+            byte[] dynvsbytes = File.ReadAllBytes(Path.Combine(folder, "PathDynVS.cso"));
+            byte[] vsbytes = File.ReadAllBytes(Path.Combine(folder, "PathVS.cso"));
+            byte[] psbytes = File.ReadAllBytes(Path.Combine(folder, "PathPS.cso"));
 
 
             boxvs = new VertexShader(device, boxvsbytes);

--- a/CodeWalker/Rendering/Shaders/PostProcessor.cs
+++ b/CodeWalker/Rendering/Shaders/PostProcessor.cs
@@ -13,6 +13,7 @@ using CodeWalker.World;
 using SharpDX;
 using SharpDX.DXGI;
 using SharpDX.Mathematics.Interop;
+using System.Diagnostics;
 
 namespace CodeWalker.Rendering
 {
@@ -186,14 +187,15 @@ namespace CodeWalker.Rendering
         {
             var device = dxman.device;
 
-            byte[] bReduceTo1DCS = File.ReadAllBytes("Shaders\\PPReduceTo1DCS.cso");
-            byte[] bReduceTo0DCS = File.ReadAllBytes("Shaders\\PPReduceTo0DCS.cso");
-            byte[] bLumBlendCS = File.ReadAllBytes("Shaders\\PPLumBlendCS.cso");
-            byte[] bBloomFilterBPHCS = File.ReadAllBytes("Shaders\\PPBloomFilterBPHCS.cso");
-            byte[] bBloomFilterVCS = File.ReadAllBytes("Shaders\\PPBloomFilterVCS.cso");
-            byte[] bCopyPixelsPS = File.ReadAllBytes("Shaders\\PPCopyPixelsPS.cso");
-            byte[] bFinalPassVS = File.ReadAllBytes("Shaders\\PPFinalPassVS.cso");
-            byte[] bFinalPassPS = File.ReadAllBytes("Shaders\\PPFinalPassPS.cso");
+            string folder = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "Shaders");
+            byte[] bReduceTo1DCS = File.ReadAllBytes(Path.Combine(folder, "PPReduceTo1DCS.cso"));
+            byte[] bReduceTo0DCS = File.ReadAllBytes(Path.Combine(folder, "PPReduceTo0DCS.cso"));
+            byte[] bLumBlendCS = File.ReadAllBytes(Path.Combine(folder, "PPLumBlendCS.cso"));
+            byte[] bBloomFilterBPHCS = File.ReadAllBytes(Path.Combine(folder, "PPBloomFilterBPHCS.cso"));
+            byte[] bBloomFilterVCS = File.ReadAllBytes(Path.Combine(folder, "PPBloomFilterVCS.cso"));
+            byte[] bCopyPixelsPS = File.ReadAllBytes(Path.Combine(folder, "PPCopyPixelsPS.cso"));
+            byte[] bFinalPassVS = File.ReadAllBytes(Path.Combine(folder, "PPFinalPassVS.cso"));
+            byte[] bFinalPassPS = File.ReadAllBytes(Path.Combine(folder, "PPFinalPassPS.cso"));
 
             ReduceTo1DCS = new ComputeShader(device, bReduceTo1DCS);
             ReduceTo0DCS = new ComputeShader(device, bReduceTo0DCS);

--- a/CodeWalker/Rendering/Shaders/Shader.cs
+++ b/CodeWalker/Rendering/Shaders/Shader.cs
@@ -10,6 +10,8 @@ using Device = SharpDX.Direct3D11.Device;
 using Buffer = SharpDX.Direct3D11.Buffer;
 using MapFlags = SharpDX.Direct3D11.MapFlags;
 using CodeWalker.World;
+using System.Diagnostics;
+using System.IO;
 
 namespace CodeWalker.Rendering
 {
@@ -25,6 +27,5 @@ namespace CodeWalker.Rendering
         public abstract void UnbindResources(DeviceContext context);
 
         //public abstract void Dispose();
-
     }
 }

--- a/CodeWalker/Rendering/Shaders/ShadowShader.cs
+++ b/CodeWalker/Rendering/Shaders/ShadowShader.cs
@@ -12,6 +12,7 @@ using MapFlags = SharpDX.Direct3D11.MapFlags;
 using SharpDX;
 using CodeWalker.GameFiles;
 using CodeWalker.World;
+using System.Diagnostics;
 
 namespace CodeWalker.Rendering
 {
@@ -81,9 +82,10 @@ namespace CodeWalker.Rendering
 
         public ShadowShader(Device device)
         {
-            byte[] vsbytes = File.ReadAllBytes("Shaders\\ShadowVS.cso");
-            byte[] vssbytes = File.ReadAllBytes("Shaders\\ShadowVS_Skin.cso");
-            byte[] psbytes = File.ReadAllBytes("Shaders\\ShadowPS.cso");
+            string folder = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "Shaders");
+            byte[] vsbytes = File.ReadAllBytes(Path.Combine(folder, "ShadowVS.cso"));
+            byte[] vssbytes = File.ReadAllBytes(Path.Combine(folder, "ShadowVS_Skin.cso"));
+            byte[] psbytes = File.ReadAllBytes(Path.Combine(folder, "ShadowPS.cso"));
 
             shadowvs = new VertexShader(device, vsbytes);
             shadowvs_skin = new VertexShader(device, vssbytes);

--- a/CodeWalker/Rendering/Shaders/SkydomeShader.cs
+++ b/CodeWalker/Rendering/Shaders/SkydomeShader.cs
@@ -11,6 +11,7 @@ using SharpDX.Direct3D11;
 using System.IO;
 using CodeWalker.GameFiles;
 using CodeWalker.World;
+using System.Diagnostics;
 
 namespace CodeWalker.Rendering
 {
@@ -131,12 +132,13 @@ namespace CodeWalker.Rendering
 
         public SkydomeShader(Device device)
         {
-            byte[] skyvsbytes = File.ReadAllBytes("Shaders\\SkydomeVS.cso");
-            byte[] skypsbytes = File.ReadAllBytes("Shaders\\SkydomePS.cso");
-            byte[] sunvsbytes = File.ReadAllBytes("Shaders\\SkySunVS.cso");
-            byte[] sunpsbytes = File.ReadAllBytes("Shaders\\SkySunPS.cso");
-            byte[] moonvsbytes = File.ReadAllBytes("Shaders\\SkyMoonVS.cso");
-            byte[] moonpsbytes = File.ReadAllBytes("Shaders\\SkyMoonPS.cso");
+            string folder = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "Shaders");
+            byte[] skyvsbytes = File.ReadAllBytes(Path.Combine(folder, "SkydomeVS.cso"));
+            byte[] skypsbytes = File.ReadAllBytes(Path.Combine(folder, "SkydomePS.cso"));
+            byte[] sunvsbytes = File.ReadAllBytes(Path.Combine(folder, "SkySunVS.cso"));
+            byte[] sunpsbytes = File.ReadAllBytes(Path.Combine(folder, "SkySunPS.cso"));
+            byte[] moonvsbytes = File.ReadAllBytes(Path.Combine(folder, "SkyMoonVS.cso"));
+            byte[] moonpsbytes = File.ReadAllBytes(Path.Combine(folder, "SkyMoonPS.cso"));
 
             skyvs = new VertexShader(device, skyvsbytes);
             skyps = new PixelShader(device, skypsbytes);

--- a/CodeWalker/Rendering/Shaders/TerrainShader.cs
+++ b/CodeWalker/Rendering/Shaders/TerrainShader.cs
@@ -12,6 +12,7 @@ using MapFlags = SharpDX.Direct3D11.MapFlags;
 using SharpDX;
 using CodeWalker.GameFiles;
 using CodeWalker.World;
+using System.Diagnostics;
 
 namespace CodeWalker.Rendering
 {
@@ -101,15 +102,16 @@ namespace CodeWalker.Rendering
 
         public TerrainShader(Device device)
         {
-            byte[] vspncct = File.ReadAllBytes("Shaders\\TerrainVS_PNCCT.cso");
-            byte[] vspncctt = File.ReadAllBytes("Shaders\\TerrainVS_PNCCTT.cso");
-            byte[] vspnccttx = File.ReadAllBytes("Shaders\\TerrainVS_PNCCTTX.cso");
-            byte[] vspncctttx = File.ReadAllBytes("Shaders\\TerrainVS_PNCCTTTX.cso");
-            byte[] vspncctx = File.ReadAllBytes("Shaders\\TerrainVS_PNCCTX.cso");
-            byte[] vspnctttx = File.ReadAllBytes("Shaders\\TerrainVS_PNCTTTX.cso");
-            byte[] vspncttx = File.ReadAllBytes("Shaders\\TerrainVS_PNCTTX.cso");
-            byte[] psbytes = File.ReadAllBytes("Shaders\\TerrainPS.cso");
-            byte[] psdefbytes = File.ReadAllBytes("Shaders\\TerrainPS_Deferred.cso");
+            string folder = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "Shaders");
+            byte[] vspncct = File.ReadAllBytes(Path.Combine(folder, "TerrainVS_PNCCT.cso"));
+            byte[] vspncctt = File.ReadAllBytes(Path.Combine(folder, "TerrainVS_PNCCTT.cso"));
+            byte[] vspnccttx = File.ReadAllBytes(Path.Combine(folder, "TerrainVS_PNCCTTX.cso"));
+            byte[] vspncctttx = File.ReadAllBytes(Path.Combine(folder, "TerrainVS_PNCCTTTX.cso"));
+            byte[] vspncctx = File.ReadAllBytes(Path.Combine(folder, "TerrainVS_PNCCTX.cso"));
+            byte[] vspnctttx = File.ReadAllBytes(Path.Combine(folder, "TerrainVS_PNCTTTX.cso"));
+            byte[] vspncttx = File.ReadAllBytes(Path.Combine(folder, "TerrainVS_PNCTTX.cso"));
+            byte[] psbytes = File.ReadAllBytes(Path.Combine(folder, "TerrainPS.cso"));
+            byte[] psdefbytes = File.ReadAllBytes(Path.Combine(folder, "TerrainPS_Deferred.cso"));
 
             pncctvs = new VertexShader(device, vspncct);
             pnccttvs = new VertexShader(device, vspncctt);

--- a/CodeWalker/Rendering/Shaders/TreesLodShader.cs
+++ b/CodeWalker/Rendering/Shaders/TreesLodShader.cs
@@ -12,6 +12,7 @@ using MapFlags = SharpDX.Direct3D11.MapFlags;
 using SharpDX;
 using CodeWalker.GameFiles;
 using CodeWalker.World;
+using System.Diagnostics;
 
 namespace CodeWalker.Rendering
 {
@@ -77,9 +78,10 @@ namespace CodeWalker.Rendering
 
         public TreesLodShader(Device device)
         {
-            byte[] vsbytes = File.ReadAllBytes("Shaders\\TreesLodVS.cso");
-            byte[] psbytes = File.ReadAllBytes("Shaders\\TreesLodPS.cso");
-            byte[] psdefbytes = File.ReadAllBytes("Shaders\\TreesLodPS_Deferred.cso");
+            string folder = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "Shaders");
+            byte[] vsbytes = File.ReadAllBytes(Path.Combine(folder, "TreesLodVS.cso"));
+            byte[] psbytes = File.ReadAllBytes(Path.Combine(folder, "TreesLodPS.cso"));
+            byte[] psdefbytes = File.ReadAllBytes(Path.Combine(folder, "TreesLodPS_Deferred.cso"));
 
             vs = new VertexShader(device, vsbytes);
             ps = new PixelShader(device, psbytes);

--- a/CodeWalker/Rendering/Shaders/WaterShader.cs
+++ b/CodeWalker/Rendering/Shaders/WaterShader.cs
@@ -8,6 +8,7 @@ using CodeWalker.World;
 using SharpDX.Direct3D11;
 using SharpDX;
 using System.IO;
+using System.Diagnostics;
 
 namespace CodeWalker.Rendering
 {
@@ -121,12 +122,13 @@ namespace CodeWalker.Rendering
 
         public WaterShader(Device device)
         {
-            byte[] vsptbytes = File.ReadAllBytes("Shaders\\WaterVS_PT.cso");
-            byte[] vspctbytes = File.ReadAllBytes("Shaders\\WaterVS_PCT.cso");
-            byte[] vspnctbytes = File.ReadAllBytes("Shaders\\WaterVS_PNCT.cso");
-            byte[] vspnctxbytes = File.ReadAllBytes("Shaders\\WaterVS_PNCTX.cso");
-            byte[] psbytes = File.ReadAllBytes("Shaders\\WaterPS.cso");
-            byte[] psdefbytes = File.ReadAllBytes("Shaders\\WaterPS_Deferred.cso");
+            string folder = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "Shaders");
+            byte[] vsptbytes = File.ReadAllBytes(Path.Combine(folder, "WaterVS_PT.cso"));
+            byte[] vspctbytes = File.ReadAllBytes(Path.Combine(folder, "WaterVS_PCT.cso"));
+            byte[] vspnctbytes = File.ReadAllBytes(Path.Combine(folder, "WaterVS_PNCT.cso"));
+            byte[] vspnctxbytes = File.ReadAllBytes(Path.Combine(folder, "WaterVS_PNCTX.cso"));
+            byte[] psbytes = File.ReadAllBytes(Path.Combine(folder, "WaterPS.cso"));
+            byte[] psdefbytes = File.ReadAllBytes(Path.Combine(folder, "WaterPS_Deferred.cso"));
 
 
             vspt = new VertexShader(device, vsptbytes);

--- a/CodeWalker/Rendering/Shaders/WidgetShader.cs
+++ b/CodeWalker/Rendering/Shaders/WidgetShader.cs
@@ -8,6 +8,7 @@ using CodeWalker.World;
 using SharpDX.Direct3D11;
 using SharpDX;
 using System.IO;
+using System.Diagnostics;
 
 namespace CodeWalker.Rendering
 {
@@ -39,8 +40,9 @@ namespace CodeWalker.Rendering
 
         public WidgetShader(Device device)
         {
-            byte[] vsbytes = File.ReadAllBytes("Shaders\\WidgetVS.cso");
-            byte[] psbytes = File.ReadAllBytes("Shaders\\WidgetPS.cso");
+            string folder = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "Shaders");
+            byte[] vsbytes = File.ReadAllBytes(Path.Combine(folder, "WidgetVS.cso"));
+            byte[] psbytes = File.ReadAllBytes(Path.Combine(folder, "WidgetPS.cso"));
 
             vs = new VertexShader(device, vsbytes);
             ps = new PixelShader(device, psbytes);

--- a/CodeWalker/WorldForm.cs
+++ b/CodeWalker/WorldForm.cs
@@ -6,6 +6,7 @@ using System.Windows.Forms;
 using System.Threading;
 using System.Diagnostics;
 using System.Linq;
+using System.IO;
 using SharpDX;
 using SharpDX.XInput;
 using Device = SharpDX.Direct3D11.Device;
@@ -314,7 +315,7 @@ namespace CodeWalker
 
         private MapIcon AddIcon(string name, string filename, int texw, int texh, float centerx, float centery, float scale)
         {
-            string filepath = "icons\\" + filename;
+            string filepath = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName), "icons", filename);
             try
             {
                 MapIcon mi = new MapIcon(name, filepath, texw, texh, centerx, centery, scale);


### PR DESCRIPTION
This allows Codewalker to be opened from things like start menu, and overall makes it more reliable with launching, since the shaders are always in the file of the executable.

This would also allow files to be opened by drag and dropping on codewalker, and other features down the line.