### PR TITLE
fix ped components

### DIFF
--- a/CodeWalker.Core/GameFiles/MetaTypes/Meta.cs
+++ b/CodeWalker.Core/GameFiles/MetaTypes/Meta.cs
@@ -1025,7 +1025,7 @@ namespace CodeWalker.GameFiles
         }
     }
 
-    [TC(typeof(EXP))]  struct ArrayOfFloats5
+    [TC(typeof(EXP))] public struct ArrayOfFloats5
     {
         public float f0, f1, f2, f3, f4;
         public float[] GetArray()

--- a/CodeWalker.Core/GameFiles/MetaTypes/Meta.cs
+++ b/CodeWalker.Core/GameFiles/MetaTypes/Meta.cs
@@ -1024,6 +1024,16 @@ namespace CodeWalker.GameFiles
             return new[] { b0, b1, b2, b3, b4 };
         }
     }
+
+    [TC(typeof(EXP))]  struct ArrayOfFloats5
+    {
+        public float f0, f1, f2, f3, f4;
+        public float[] GetArray()
+        {
+            return new[] { f0, f1, f2, f3, f4 };
+        }
+    }
+
     [TC(typeof(EXP))] public struct ArrayOfBytes6 //array of 6 bytes
     {
         public byte b0, b1, b2, b3, b4, b5;

--- a/CodeWalker.Core/GameFiles/MetaTypes/MetaTypes.cs
+++ b/CodeWalker.Core/GameFiles/MetaTypes/MetaTypes.cs
@@ -6393,7 +6393,7 @@ namespace CodeWalker.GameFiles
     {
         public MetaHash pedXml_audioID { get; set; } //0   0: Hash: 0: 802196719
         public MetaHash pedXml_audioID2 { get; set; } //4   4: Hash: 0: 4233133352
-        public ArrayOfBytes5 pedXml_expressionMods { get; set; } //8   8: ArrayOfBytes: 5: 128864925
+        public ArrayOfFloats5 pedXml_expressionMods { get; set; } //8   8: ArrayOfBytes: 5: 128864925
         public byte Unused0 { get; set; }//13
         public ushort Unused1 { get; set; }//14
         public uint Unused2 { get; set; }//16


### PR DESCRIPTION
originally set as array of 5 bytes, when its actually an array of 5 floats.