### PR TITLE
Fix .ydd export/import with unsolved hashes

### DIFF
--- a/CodeWalker.Core/GameFiles/FileTypes/YddFile.cs
+++ b/CodeWalker.Core/GameFiles/FileTypes/YddFile.cs
@@ -76,13 +76,7 @@ namespace CodeWalker.GameFiles
                     var hash = hashes[i];
                     if ((drawable.Name == null) || (drawable.Name.EndsWith("#dd")))
                     {
-                        string hstr = JenkIndex.TryGetString(hash);
-                        if (!string.IsNullOrEmpty(hstr))
-                        {
-                            drawable.Name = hstr;
-                        }
-                        else
-                        { }
+                        drawable.Name = YddXml.HashString((MetaHash)hash);
                     }
                 }
 

--- a/CodeWalker.Core/GameFiles/Resources/Drawable.cs
+++ b/CodeWalker.Core/GameFiles/Resources/Drawable.cs
@@ -5847,7 +5847,7 @@ namespace CodeWalker.GameFiles
                     var d = new Drawable();
                     d.ReadXml(inode, ddsfolder);
                     drawables.Add(d);
-                    drawablehashes.Add(JenkHash.GenHash(d.Name));//TODO: check this!
+                    drawablehashes.Add(XmlMeta.GetHash(d.Name));
                 }
             }
 


### PR DESCRIPTION
When a drawable hash was unknown, it kept the "filename.#dd" name so exporting to XML lost the hash and importing it back created a broken file.

Now if the hash is unknown, the name is set to `hash_1234ABCD`, and XML import checks for `hash_`.