### PR TITLE
Replace Dec3N vertex format with RGBA8 SNorm

### DIFF
--- a/CodeWalker.Core/GameFiles/Resources/VertexType.cs
+++ b/CodeWalker.Core/GameFiles/Resources/VertexType.cs
@@ -19,7 +19,7 @@ namespace CodeWalker.GameFiles
         Float4 = 7,
         UByte4 = 8,
         Colour = 9,
-        Dec3N = 10,
+        RGBA8SNorm = 10,
         Unk1 = 11,
         Unk2 = 12,
         Unk3 = 13,
@@ -43,7 +43,7 @@ namespace CodeWalker.GameFiles
                 case VertexComponentType.Float4: return 16;
                 case VertexComponentType.UByte4: return 4;
                 case VertexComponentType.Colour: return 4;
-                case VertexComponentType.Dec3N: return 4;
+                case VertexComponentType.RGBA8SNorm: return 4;
                 default: return 0;
             }
         }
@@ -62,7 +62,7 @@ namespace CodeWalker.GameFiles
                 case VertexComponentType.Float4: return 4;
                 case VertexComponentType.UByte4: return 4;
                 case VertexComponentType.Colour: return 4;
-                case VertexComponentType.Dec3N: return 4;
+                case VertexComponentType.RGBA8SNorm: return 4;
                 default: return 0;
             }
         }

--- a/CodeWalker/Rendering/VertexTypes.cs
+++ b/CodeWalker/Rendering/VertexTypes.cs
@@ -46,7 +46,7 @@ namespace CodeWalker.Rendering
                 case VertexComponentType.Float4: return Format.R32G32B32A32_Float;
                 case VertexComponentType.UByte4: return Format.R8G8B8A8_UInt;
                 case VertexComponentType.Colour: return Format.R8G8B8A8_UNorm;
-                case VertexComponentType.Dec3N: return Format.R10G10B10A2_UNorm;
+                case VertexComponentType.RGBA8SNorm: return Format.R8G8B8A8_SNorm;
                 default: return Format.Unknown;
             }
         }


### PR DESCRIPTION
The game uses DXGI_FORMAT_R8G8B8A8_SNORM when building the D3D11 input-layout for what CW called Dec3N.

Updated XML import/export to correctly read these values.