### PR TITLE
Update from .net Framework to .NET 8.0

### DIFF
--- a/CodeWalker.Core/CodeWalker.Core.csproj
+++ b/CodeWalker.Core/CodeWalker.Core.csproj
@@ -1,20 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="SharpDX" Version="4.2.0" />
     <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
   </ItemGroup>
-
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
-
   <ItemGroup>
     <Resource Include="Resources\magic.dat" />
   </ItemGroup>
-
 </Project>

--- a/CodeWalker.Core/Utils/Utils.cs
+++ b/CodeWalker.Core/Utils/Utils.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading.Tasks;
 using SharpDX;
 using Color = SharpDX.Color;
+using Half = SharpDX.Half;
 
 namespace CodeWalker
 {

--- a/CodeWalker.ErrorReport/CodeWalker.ErrorReport.csproj
+++ b/CodeWalker.ErrorReport/CodeWalker.ErrorReport.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>CW.ico</ApplicationIcon>
     <AssemblyName>CodeWalker Error Report Tool</AssemblyName>
   </PropertyGroup>
-
 </Project>

--- a/CodeWalker.Peds/CodeWalker.Peds.csproj
+++ b/CodeWalker.Peds/CodeWalker.Peds.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>CWPeds.ico</ApplicationIcon>
     <Copyright>dexyfex</Copyright>
@@ -10,13 +9,10 @@
     <Authors>dexyfex</Authors>
     <AssemblyName>CodeWalker Ped Viewer</AssemblyName>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\CodeWalker\CodeWalker.csproj" />
   </ItemGroup>
-
 </Project>

--- a/CodeWalker.RPFExplorer/CodeWalker.RPFExplorer.csproj
+++ b/CodeWalker.RPFExplorer/CodeWalker.RPFExplorer.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>CWRPFExplorer.ico</ApplicationIcon>
@@ -11,13 +10,10 @@
     <Authors>dexyfex</Authors>
     <AssemblyName>CodeWalker RPF Explorer</AssemblyName>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\CodeWalker\CodeWalker.csproj" />
   </ItemGroup>
-
 </Project>

--- a/CodeWalker.Vehicles/CodeWalker.Vehicles.csproj
+++ b/CodeWalker.Vehicles/CodeWalker.Vehicles.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>CWVehicles.ico</ApplicationIcon>
     <Copyright>dexyfex</Copyright>
@@ -10,13 +9,10 @@
     <Authors>dexyfex</Authors>
     <AssemblyName>CodeWalker Vehicle Viewer</AssemblyName>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\CodeWalker\CodeWalker.csproj" />
   </ItemGroup>
-
 </Project>

--- a/CodeWalker.WinForms/CodeWalker.WinForms.csproj
+++ b/CodeWalker.WinForms/CodeWalker.WinForms.csproj
@@ -1,15 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net48</TargetFramework>
+	  <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
+	  <UseWPF>true</UseWPF>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="DockPanelSuite.ThemeVS2015" Version="3.0.6" />
+    <PackageReference Include="DockPanelSuite.ThemeVS2015" Version="3.1.1" />
     <PackageReference Include="SharpDX" Version="4.2.0" />
     <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
   </ItemGroup>
-
 </Project>

--- a/CodeWalker/CodeWalker.csproj
+++ b/CodeWalker/CodeWalker.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>CW.ico</ApplicationIcon>
@@ -10,14 +9,13 @@
     <Company>dexyfex software</Company>
     <Authors>dexyfex</Authors>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="DockPanelSuite.ThemeVS2015" Version="3.0.6" />
+    <PackageReference Include="DockPanelSuite.ThemeVS2015" Version="3.1.1" />
     <PackageReference Include="FCTB" Version="2.16.24" />
+    <PackageReference Include="OxyPlot.WindowsForms" Version="2.1.2" />
     <PackageReference Include="SharpDX" Version="4.2.0" />
     <PackageReference Include="SharpDX.D3DCompiler" Version="4.2.0" />
     <PackageReference Include="SharpDX.Direct2D1" Version="4.2.0" />
@@ -26,16 +24,10 @@
     <PackageReference Include="SharpDX.XAudio2" Version="4.2.0" />
     <PackageReference Include="SharpDX.XInput" Version="4.2.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\CodeWalker.Core\CodeWalker.Core.csproj" />
     <ProjectReference Include="..\CodeWalker.WinForms\CodeWalker.WinForms.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Windows.Forms.DataVisualization" />
-  </ItemGroup>
-
   <ItemGroup>
     <Compile Update="Properties\Settings.Designer.cs">
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
@@ -43,12 +35,10 @@
       <DependentUpon>Settings.settings</DependentUpon>
     </Compile>
   </ItemGroup>
-
   <ItemGroup>
     <None Update="Properties\Settings.settings">
       <Generator>PublicSettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
   </ItemGroup>
-
 </Project>

--- a/CodeWalker/Forms/RelForm.Designer.cs
+++ b/CodeWalker/Forms/RelForm.Designer.cs
@@ -30,9 +30,7 @@
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(RelForm));
-            System.Windows.Forms.DataVisualization.Charting.ChartArea chartArea1 = new System.Windows.Forms.DataVisualization.Charting.ChartArea();
-            System.Windows.Forms.DataVisualization.Charting.Legend legend1 = new System.Windows.Forms.DataVisualization.Charting.Legend();
-            System.Windows.Forms.DataVisualization.Charting.Series series1 = new System.Windows.Forms.DataVisualization.Charting.Series();
+            OxyPlot.PlotModel plotView = new OxyPlot.PlotModel();
             this.RelPropertyGrid = new CodeWalker.WinForms.PropertyGridFix();
             this.MainTabControl = new System.Windows.Forms.TabControl();
             this.XmlTabPage = new System.Windows.Forms.TabPage();
@@ -53,7 +51,7 @@
             this.label2 = new System.Windows.Forms.Label();
             this.SynthVariablesTextBox = new System.Windows.Forms.TextBox();
             this.SynthOutputsTextBox = new System.Windows.Forms.TextBox();
-            this.SynthBufferChart = new System.Windows.Forms.DataVisualization.Charting.Chart();
+            this.plotView1 = new OxyPlot.WindowsForms.PlotView();
             this.SynthPlayButton = new System.Windows.Forms.Button();
             this.SynthCopyXMLButton = new System.Windows.Forms.Button();
             this.label1 = new System.Windows.Forms.Label();
@@ -86,7 +84,7 @@
             this.NameTableTabPage.SuspendLayout();
             this.SearchTabPage.SuspendLayout();
             this.SynthsTabPage.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.SynthBufferChart)).BeginInit();
+            this.plotView1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.SynthTextBox)).BeginInit();
             this.MainToolbar.SuspendLayout();
             this.MainStatusStrip.SuspendLayout();
@@ -297,7 +295,7 @@
             this.SynthsTabPage.Controls.Add(this.label2);
             this.SynthsTabPage.Controls.Add(this.SynthVariablesTextBox);
             this.SynthsTabPage.Controls.Add(this.SynthOutputsTextBox);
-            this.SynthsTabPage.Controls.Add(this.SynthBufferChart);
+            this.SynthsTabPage.Controls.Add(this.plotView1);
             this.SynthsTabPage.Controls.Add(this.SynthPlayButton);
             this.SynthsTabPage.Controls.Add(this.SynthCopyXMLButton);
             this.SynthsTabPage.Controls.Add(this.label1);
@@ -360,23 +358,18 @@
             // 
             // SynthBufferChart
             // 
-            this.SynthBufferChart.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.plotView1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
-            chartArea1.Name = "ChartArea1";
-            this.SynthBufferChart.ChartAreas.Add(chartArea1);
-            legend1.Name = "Legend1";
-            this.SynthBufferChart.Legends.Add(legend1);
-            this.SynthBufferChart.Location = new System.Drawing.Point(363, 31);
-            this.SynthBufferChart.Name = "SynthBufferChart";
-            series1.ChartArea = "ChartArea1";
-            series1.ChartType = System.Windows.Forms.DataVisualization.Charting.SeriesChartType.Line;
-            series1.IsXValueIndexed = true;
-            series1.Legend = "Legend1";
-            series1.Name = "Buffer";
-            this.SynthBufferChart.Series.Add(series1);
-            this.SynthBufferChart.Size = new System.Drawing.Size(460, 112);
-            this.SynthBufferChart.TabIndex = 38;
-            this.SynthBufferChart.Text = "chart1";
+            var plotModel = new OxyPlot.PlotModel();
+            this.plotView1.Location = new System.Drawing.Point(363, 31);
+            this.plotView1.Name = "SynthBufferChart";
+            plotModel.Series.Add(new OxyPlot.Series.LineSeries { Title = "Buffer", LegendKey = "Main" });
+            plotModel.IsLegendVisible = true;
+            plotModel.Legends.Add(new OxyPlot.Legends.Legend { LegendPosition = OxyPlot.Legends.LegendPosition.RightMiddle, LegendPlacement = OxyPlot.Legends.LegendPlacement.Outside, LegendOrientation = OxyPlot.Legends.LegendOrientation.Horizontal, Key = "Main" });
+            this.plotView1.Model = plotModel;
+            this.plotView1.Size = new System.Drawing.Size(460, 112);
+            this.plotView1.TabIndex = 38;
+            this.plotView1.Text = "chart1";
             // 
             // SynthPlayButton
             // 
@@ -649,7 +642,8 @@
             this.SearchTabPage.PerformLayout();
             this.SynthsTabPage.ResumeLayout(false);
             this.SynthsTabPage.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.SynthBufferChart)).EndInit();
+            this.plotView1.ResumeLayout(false);
+            this.plotView1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.SynthTextBox)).EndInit();
             this.MainToolbar.ResumeLayout(false);
             this.MainToolbar.PerformLayout();
@@ -704,7 +698,7 @@
         private FastColoredTextBoxNS.FastColoredTextBox SynthTextBox;
         private System.Windows.Forms.Button SynthCopyXMLButton;
         private System.Windows.Forms.Button SynthPlayButton;
-        private System.Windows.Forms.DataVisualization.Charting.Chart SynthBufferChart;
+        private OxyPlot.WindowsForms.PlotView plotView1;
         private System.Windows.Forms.TextBox SynthOutputsTextBox;
         private System.Windows.Forms.TextBox SynthVariablesTextBox;
         private System.Windows.Forms.Label label3;

--- a/CodeWalker/Forms/RelForm.cs
+++ b/CodeWalker/Forms/RelForm.cs
@@ -12,7 +12,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.Windows.Forms.DataVisualization.Charting;
+using OxyPlot;
+using OxyPlot.Series;
 using System.Xml;
 using Range = FastColoredTextBoxNS.Range;
 using TextStyle = FastColoredTextBoxNS.TextStyle;
@@ -750,12 +751,16 @@ namespace CodeWalker.Forms
                                 int i = synthesizer.Synth.OutputsIndices[0];
                                 try
                                 {
-                                    var series = SynthBufferChart.Series.FindByName($"B{i}");
+                                    var series = plotView1.Model.Series.FirstOrDefault(p => p.Title == $"B{i}") as LineSeries;
                                     if (series != null)
                                     {
                                         series.Points.Clear();
-                                        foreach (var v in buffersCopy[i])
-                                            series.Points.AddY(Math.Max(Math.Min(v, 2.0f), -2.0f));//make sure crazy accidental values don't crash it later
+                                        var thisBuffer = buffersCopy[i];
+                                        for (int j = 0; j < thisBuffer.Length; j++)
+                                        {
+                                            series.Points.Add(new DataPoint(j, Math.Max(Math.Min(thisBuffer[j], 2.0f), -2.0f)));
+                                        }
+                                        plotView1.InvalidatePlot(true);
                                     }
                                 }
                                 catch { }
@@ -763,12 +768,13 @@ namespace CodeWalker.Forms
                         };
                     }
 
-                    SynthBufferChart.Series.Clear();
+                    plotView1.Model.Series.Clear();
+                    //plotView1.Model.GetLegend("Main");
                     for (int i = 0; i < newSynth.BuffersCount; i++)
                     {
-                        var series = SynthBufferChart.Series.Add($"B{i}");
-                        series.IsXValueIndexed = true;
-                        series.ChartType = SeriesChartType.FastLine;
+                        
+                        plotView1.Model.Series.Add(new LineSeries { Title = $"B{i}", RenderInLegend = true, LegendKey = $"Main" });
+                        //plotView1.Model.Legends.Add(new OxyPlot.Legends.Legend { LegendPosition = OxyPlot.Legends.LegendPosition.RightMiddle, LegendPlacement = OxyPlot.Legends.LegendPlacement.Outside, LegendOrientation = OxyPlot.Legends.LegendOrientation.Vertical, Key = $"B{i}" });
                     }
 
                     SynthPlayButton.Enabled = false;


### PR DESCRIPTION
As per the previous pull request, which was quite large and contained a lot of unecessary optimizations.

So reduced it to only include the update to .net 8.0 for now.

Only required switching from DataVizualisation to an external package, and switched the WinForms Open Folder util to WPF.

My reasoning behind this update is to allow the project to be more modern, so allow features like Span and Memory which can save a lot of Array copying, and this also unlocks a lot of new .NET features.

And since .NET is so backwards compatible this doesn't change the behavior whatsoever (besides the fact that WinForms updated it's look a little bit so the UI looks a little bit different)