### PR TITLE
Fix MLO Instance Data...

### DIFF
--- a/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs
+++ b/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs
@@ -1813,8 +1813,8 @@ namespace CodeWalker.GameFiles
                 {
                     //transform interior entities into world space...
                     var mloa = Archetype as MloArchetype;
-                    MloInstance = new MloInstanceData(this, mloa);
-                    MloInstance._Instance = new CMloInstanceDef { CEntityDef = _CEntityDef };
+                    var mloi = MloInstance;
+                    MloInstance = new MloInstanceData(this, mloa) { Instance = mloi.Instance, defaultEntitySets = mloi.defaultEntitySets };
                     if (mloa != null)
                     {
                         if (!IsMlo)


### PR DESCRIPTION
Fixing MLO Instance Data - `groupId`, `floorId`, `defaultEntitySets`*?, `numExitPortals`, `MLOInstflags`. *There is a bug with **defaultEntitySets** - it is not possible to get and set data items, for example in vanilla files `v_metro_interior_metro_station_3_seoul_milo__3.ymap`, probably incorrect offset, parsing, etc, we get null: [https://github.com/dexyfex/CodeWalker/blob/c45ea837330864c03ca5f355fd38affab85e46c5/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs#L301](https://github.com/dexyfex/CodeWalker/blob/c45ea837330864c03ca5f355fd38affab85e46c5/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs#L301)