### PR TITLE
Fix MLO Instance Data

### DIFF
--- a/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs
+++ b/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs
@@ -298,7 +298,7 @@ namespace CodeWalker.GameFiles
                     for (int i = 0; i < CMloInstanceDefs.Length; i++)
                     {
                         YmapEntityDef d = new YmapEntityDef(this, i, ref CMloInstanceDefs[i]);
-                        uint[] defentsets = MetaTypes.GetUintArray(Meta, CMloInstanceDefs[i].defaultEntitySets);
+                        MetaHash[] defentsets = MetaTypes.GetHashArray(Meta, CMloInstanceDefs[i].defaultEntitySets);
                         if (d.MloInstance != null)
                         {
                             d.MloInstance.defaultEntitySets = defentsets;
@@ -657,7 +657,7 @@ namespace CodeWalker.GameFiles
                         ent.MloInstance.UpdateDefaultEntitySets();
 
                         ent.MloInstance._Instance.CEntityDef = ent.CEntityDef; //overwrite with all the updated values..
-                        ent.MloInstance._Instance.defaultEntitySets = mb.AddUintArrayPtr(ent.MloInstance.defaultEntitySets);
+                        ent.MloInstance._Instance.defaultEntitySets = mb.AddHashArrayPtr(ent.MloInstance.defaultEntitySets);
 
                         ptrs[i] = mb.AddItemPtr(MetaName.CMloInstanceDef, ent.MloInstance.Instance);
                     }

--- a/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs
+++ b/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs
@@ -1813,8 +1813,8 @@ namespace CodeWalker.GameFiles
                 {
                     //transform interior entities into world space...
                     var mloa = Archetype as MloArchetype;
-                    MloInstance = new MloInstanceData(this, mloa);
-                    MloInstance._Instance = new CMloInstanceDef { CEntityDef = _CEntityDef };
+                    var mloi = MloInstance;
+                    MloInstance = new MloInstanceData(this, mloa) { Instance = mloi.Instance, defaultEntitySets = mloi.defaultEntitySets };
                     if (mloa != null)
                     {
                         if (!IsMlo)

--- a/CodeWalker.Core/GameFiles/MetaTypes/Archetype.cs
+++ b/CodeWalker.Core/GameFiles/MetaTypes/Archetype.cs
@@ -600,7 +600,7 @@ namespace CodeWalker.GameFiles
         public MloArchetype MloArch { get; set; }
         public CMloInstanceDef _Instance;
         public CMloInstanceDef Instance { get { return _Instance; } set { _Instance = value; } }
-        public uint[] defaultEntitySets { get; set; }
+        public MetaHash[] defaultEntitySets { get; set; }
 
         public YmapEntityDef[] Entities { get; set; }
         public MloInstanceEntitySet[] EntitySets { get; set; }
@@ -652,10 +652,17 @@ namespace CodeWalker.GameFiles
             {
                 for (var i = 0; i < defaultEntitySets.Length; i++)
                 {
-                    uint index = defaultEntitySets[i];
-                    if (index >= EntitySets.Length) continue;
-                    var instset = EntitySets[index];
-                    instset.Visible = true;
+                    MetaHash defentsets = defaultEntitySets[i];
+                    string defentsetsName = defentsets.ToString();
+
+                    for (var j = 0; j < EntitySets.Length; j++)
+                    {
+                        if (defentsetsName == EntitySets[j].EntitySet.Name)
+                        {
+                            EntitySets[j].Visible = true;
+                            break;
+                        }
+                    }
                 }
             }
 
@@ -958,24 +965,19 @@ namespace CodeWalker.GameFiles
 
         public void UpdateDefaultEntitySets()
         {
-            var list = new List<uint>();
+            if (EntitySets == null) return;
+            var visibleSets = new List<MetaHash>();
 
-            if (EntitySets != null)
+            for (int i = 0; i < EntitySets.Length; i++)
             {
-                for (uint i = 0; i < EntitySets.Length; i++)
+                if (EntitySets[i].Visible)
                 {
-                    var entset = EntitySets[i];
-                    if (entset != null)
-                    {
-                        if (entset.Visible)
-                        {
-                            list.Add(i);
-                        }
-                    }
+                    string entitySetName = EntitySets[i].EntitySet.Name;
+                    uint namehash = JenkHash.GenHash(entitySetName);
+                    visibleSets.Add(new MetaHash(namehash));
                 }
             }
-
-            defaultEntitySets = list.ToArray();
+            defaultEntitySets = visibleSets.ToArray();
         }
 
         private void UpdateAllEntityIndexes()

--- a/CodeWalker.Core/GameFiles/MetaTypes/Archetype.cs
+++ b/CodeWalker.Core/GameFiles/MetaTypes/Archetype.cs
@@ -966,18 +966,19 @@ namespace CodeWalker.GameFiles
         public void UpdateDefaultEntitySets()
         {
             if (EntitySets == null) return;
-            var visibleSets = new List<MetaHash>();
+            var list = new List<MetaHash>();
 
             for (int i = 0; i < EntitySets.Length; i++)
             {
                 if (EntitySets[i].Visible)
                 {
-                    string entitySetName = EntitySets[i].EntitySet.Name;
-                    uint namehash = JenkHash.GenHash(entitySetName);
-                    visibleSets.Add(new MetaHash(namehash));
+                    string entsetName = EntitySets[i].EntitySet.Name;
+                    uint nameHash = JenkHash.GenHash(entsetName);
+                    list.Add(new MetaHash(nameHash));
                 }
             }
-            defaultEntitySets = visibleSets.ToArray();
+
+            defaultEntitySets = list.ToArray();
         }
 
         private void UpdateAllEntityIndexes()


### PR DESCRIPTION
Fixing MLO Instance Data - `groupId`, `floorId`, `defaultEntitySets`*, `numExitPortals`, `MLOInstflags`. 
*There is a bug with **defaultEntitySets** - it is not possible to get and set data items, for example in vanilla files `v_metro_interior_metro_station_3_seoul_milo__3.ymap`, probably incorrect offset, parsing, etc, we get null: [https://github.com/dexyfex/CodeWalker/blob/c45ea837330864c03ca5f355fd38affab85e46c5/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs#L301](https://github.com/dexyfex/CodeWalker/blob/c45ea837330864c03ca5f355fd38affab85e46c5/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs#L301)