### PR TITLE
Add drag-and-drop support for YTD form

### DIFF
--- a/CodeWalker.Core/GameFiles/Resources/Texture.cs
+++ b/CodeWalker.Core/GameFiles/Resources/Texture.cs
@@ -3,16 +3,15 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 
 namespace CodeWalker.GameFiles
 {
 
 
-    [TypeConverter(typeof(ExpandableObjectConverter))] public class TextureDictionary : ResourceFileBase
+    [TypeConverter(typeof(ExpandableObjectConverter))]
+    public class TextureDictionary : ResourceFileBase
     {
         public override long BlockLength
         {
@@ -172,7 +171,7 @@ namespace CodeWalker.GameFiles
         public void BuildFromTextureList(List<Texture> textures)
         {
             textures.Sort((a, b) => a.NameHash.CompareTo(b.NameHash));
-            
+
             var texturehashes = new List<uint>();
             foreach (var tex in textures)
             {
@@ -188,7 +187,8 @@ namespace CodeWalker.GameFiles
 
     }
 
-    [TypeConverter(typeof(ExpandableObjectConverter))] public class TextureBase : ResourceSystemBlock
+    [TypeConverter(typeof(ExpandableObjectConverter))]
+    public class TextureBase : ResourceSystemBlock
     {
         public override long BlockLength
         {
@@ -430,7 +430,8 @@ namespace CodeWalker.GameFiles
         }
     }
 
-    [TypeConverter(typeof(ExpandableObjectConverter))] public class Texture : TextureBase
+    [TypeConverter(typeof(ExpandableObjectConverter))]
+    public class Texture : TextureBase
     {
         public override long BlockLength
         {
@@ -472,6 +473,23 @@ namespace CodeWalker.GameFiles
                     val += Data.FullData.LongLength;
                 }
                 return val;
+            }
+        }
+
+        /// <summary>
+        /// Checks if the <see cref="Texture.Width"/> and <see cref="Texture.Height"/> are powers of two.
+        /// </summary>
+        /// <remarks>
+        /// It is not necessary for the <see cref="Texture.Width"/> and <see cref="Texture.Height"/> to be the same.
+        /// </remarks>
+        /// <value>
+        /// <see langword="true"/> if the <see cref="Texture.Width"/> and <see cref="Texture.Height"/> are powers of two; otherwise, <see langword="false"/>.
+        /// </value>
+        public bool IsPowerOf2
+        {
+            get
+            {
+                return (Width & (Width - 1)) == 0 && (Height & (Height - 1)) == 0;
             }
         }
 
@@ -612,7 +630,8 @@ namespace CodeWalker.GameFiles
         }
     }
 
-    [TypeConverter(typeof(ExpandableObjectConverter))] public class TextureData : ResourceGraphicsBlock
+    [TypeConverter(typeof(ExpandableObjectConverter))]
+    public class TextureData : ResourceGraphicsBlock
     {
         public override long BlockLength
         {

--- a/CodeWalker/Forms/YtdForm.Designer.cs
+++ b/CodeWalker/Forms/YtdForm.Designer.cs
@@ -310,6 +310,7 @@
             // 
             // TexturesListView
             // 
+            this.TexturesListView.AllowDrop = true;
             this.TexturesListView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
@@ -326,6 +327,8 @@
             this.TexturesListView.UseCompatibleStateImageBehavior = false;
             this.TexturesListView.View = System.Windows.Forms.View.Details;
             this.TexturesListView.SelectedIndexChanged += new System.EventHandler(this.TexturesListView_SelectedIndexChanged);
+            this.TexturesListView.DragDrop += new System.Windows.Forms.DragEventHandler(this.TexturesListView_DragDrop);
+            this.TexturesListView.DragEnter += new System.Windows.Forms.DragEventHandler(this.TexturesListView_DragEnter);
             // 
             // TextureNameColumnHeader
             // 


### PR DESCRIPTION
## Goal of this PR
Provide a more convenient method for importing multiple textures at once into a YTD file (drag & drop), including validation checks to ensure that texture dimensions (height and width) are powers of 2.

## How is this PR achieving the goal
Updates the AddTexture method in YtdForm to validate imported file. Adds a drag-and-drop event that checks each file, showing an error message if the file is not in DDS format, if its width or height is not a power of 2, or if a texture with the same name already exists in the YTD.