### PR TITLE
fix(lodlights): only assign corona intensity if size is not 0

### DIFF
--- a/CodeWalker/Project/Panels/GenerateLODLightsPanel.cs
+++ b/CodeWalker/Project/Panels/GenerateLODLightsPanel.cs
@@ -166,7 +166,10 @@ namespace CodeWalker.Project.Panels
                                     light.hash = h;
                                     light.coneInnerAngle = inner;
                                     light.coneOuterAngleOrCapExt = outer;
-                                    light.coronaIntensity = (byte)(la.CoronaIntensity * 6);
+                                    if (la.CoronaSize != 0)
+                                    {
+                                        light.coronaIntensity = (byte)(la.CoronaIntensity * 6);
+                                    }
                                     light.isStreetLight = isStreetLight;
                                     lights.Add(light);
 


### PR DESCRIPTION
previously, when generating LOD lights the corona intensity would be set even though the source light had its corona disabled by setting the size to 0.