### PR TITLE
fix(ydd): add additional drawable name check

### DIFF
--- a/CodeWalker.Core/GameFiles/FileTypes/YddFile.cs
+++ b/CodeWalker.Core/GameFiles/FileTypes/YddFile.cs
@@ -74,7 +74,7 @@ namespace CodeWalker.GameFiles
                 {
                     var drawable = drawables[i];
                     var hash = hashes[i];
-                    if ((drawable.Name == null) || (drawable.Name.EndsWith("#dd")))
+                    if ((drawable.Name == null) || (drawable.Name.EndsWith("#dd")) || (drawable.Name.EndsWith("#dr"))) 
                     {
                         drawable.Name = YddXml.HashString((MetaHash)hash);
                     }


### PR DESCRIPTION
this will fix any drawables inside a ydd ending in #dr, so the hash / name is exported properly