### PR TITLE
Fix editing gizmo in 2D Camera

### DIFF
--- a/CodeWalker.Core/World/Camera.cs
+++ b/CodeWalker.Core/World/Camera.cs
@@ -136,7 +136,7 @@ namespace CodeWalker.World
                 }
                 LocalLookAt = Vector3.Zero;
                 Position = cpos;
-                //Position.Z = 1000.0f;
+                Position.Z = 1000.0f;
                 ViewDirection = -Vector3.UnitZ;
                 UpDirection = Vector3.UnitY;
             }


### PR DESCRIPTION
Fixing cases: If in 3D view the camera is below the object gizmo, after switching to 2D we cannot control the object gizmo or it is blocked