### PR TITLE
Always overwrite drawable name with key from drawable dictionary

### DIFF
--- a/CodeWalker.Core/GameFiles/FileTypes/YddFile.cs
+++ b/CodeWalker.Core/GameFiles/FileTypes/YddFile.cs
@@ -74,7 +74,7 @@ namespace CodeWalker.GameFiles
                 {
                     var drawable = drawables[i];
                     var hash = hashes[i];
-                    if ((drawable.Name == null) || (drawable.Name.EndsWith("#dd")))
+                    if ((drawable.Name == null) || (JenkHash.GenHash(drawable.Name) != hash))
                     {
                         drawable.Name = YddXml.HashString((MetaHash)hash);
                     }


### PR DESCRIPTION
Some modded .ydd don't follow the .#dd naming (Zmodeler exported peds for example), so don't check that.

The hash check is just in case the drawable contains the solved string but isn't registered in JenkIndex, to avoid HashString from overwriting it to `hash_123`. 