### PR TITLE
asynchronously load assets for LOD light generator

### DIFF
--- a/CodeWalker.Core/GameFiles/GameFileCache.cs
+++ b/CodeWalker.Core/GameFiles/GameFileCache.cs
@@ -2738,82 +2738,71 @@ namespace CodeWalker.GameFiles
             return drawable;
         }
 
-        public DrawableBase TryGetDrawable(Archetype arche, out bool waitingForLoad)
+        public async Task<(DrawableBase drawable, bool waitingForLoad)> TryGetDrawableAsync(Archetype arche)
         {
-            waitingForLoad = false;
-            if (arche == null) return null;
+            bool waitingForLoad = false;
+            if (arche == null) return (null, false);
+
             uint drawhash = arche.Hash;
             DrawableBase drawable = null;
-            if ((arche.DrawableDict != 0))// && (arche.DrawableDict != arche.Hash))
+
+            // Run Ydd, Ydr, and Yft parts in parallel
+            var yddTask = Task.Run(() => TryGetDrawableFromYdd(arche, drawhash, ref drawable));
+            var ydrTask = Task.Run(() => TryGetDrawableFromYdr(drawhash, ref drawable));
+            var yftTask = Task.Run(() => TryGetDrawableFromYft(drawhash, ref drawable));
+
+            // Wait for any of them to complete
+            await Task.WhenAny(yddTask, ydrTask, yftTask);
+
+            // After any task completes, check if drawable is loaded or if we are still waiting
+            if (drawable != null) return (drawable, waitingForLoad);
+
+            // If all tasks are still running, check their load status
+            if (yddTask.Status != TaskStatus.RanToCompletion || ydrTask.Status != TaskStatus.RanToCompletion || yftTask.Status != TaskStatus.RanToCompletion)
             {
-                //try get drawable from ydd...
-                YddFile ydd = GetYdd(arche.DrawableDict);
-                if (ydd != null)
-                {
-                    if (ydd.Loaded)
-                    {
-                        if (ydd.Dict != null)
-                        {
-                            Drawable d;
-                            ydd.Dict.TryGetValue(drawhash, out d); //can't out to base class?
-                            drawable = d;
-                            if (drawable == null)
-                            {
-                                return null; //drawable wasn't in dict!!
-                            }
-                        }
-                        else
-                        {
-                            return null; //ydd has no dict
-                        }
-                    }
-                    else
-                    {
-                        waitingForLoad = true;
-                        return null; //ydd not loaded yet
-                    }
-                }
-                else
-                {
-                    //return null; //couldn't find drawable dict... quit now?
-                }
-            }
-            if (drawable == null)
-            {
-                //try get drawable from ydr.
-                YdrFile ydr = GetYdr(drawhash);
-                if (ydr != null)
-                {
-                    if (ydr.Loaded)
-                    {
-                        drawable = ydr.Drawable;
-                    }
-                    else
-                    {
-                        waitingForLoad = true;
-                    }
-                }
-                else
-                {
-                    YftFile yft = GetYft(drawhash);
-                    if (yft != null)
-                    {
-                        if (yft.Loaded)
-                        {
-                            if (yft.Fragment != null)
-                            {
-                                drawable = yft.Fragment.Drawable;
-                            }
-                        }
-                        else
-                        {
-                            waitingForLoad = true;
-                        }
-                    }
-                }
+                waitingForLoad = true;
+                return (null, true); // Not ready yet, return early
             }
 
-            return drawable;
+            return (drawable, waitingForLoad);
+        }
+
+        // Helper functions for Ydd, Ydr, and Yft
+
+        private void TryGetDrawableFromYdd(Archetype arche, uint drawhash, ref DrawableBase drawable)
+        {
+            if (arche.DrawableDict != 0)
+            {
+                YddFile ydd = GetYdd(arche.DrawableDict);
+                if (ydd != null && ydd.Loaded && ydd.Dict != null && ydd.Dict.TryGetValue(drawhash, out Drawable d))
+                {
+                    drawable = d;
+                }
+            }
+        }
+
+        private void TryGetDrawableFromYdr(uint drawhash, ref DrawableBase drawable)
+        {
+            if (drawable == null)
+            {
+                YdrFile ydr = GetYdr(drawhash);
+                if (ydr != null && ydr.Loaded)
+                {
+                    drawable = ydr.Drawable;
+                }
+            }
+        }
+
+        private void TryGetDrawableFromYft(uint drawhash, ref DrawableBase drawable)
+        {
+            if (drawable == null)
+            {
+                YftFile yft = GetYft(drawhash);
+                if (yft != null && yft.Loaded)
+                {
+                    drawable = yft.Fragment?.Drawable;
+                }
+            }
         }
 
 

--- a/CodeWalker/Project/Panels/GenerateLODLightsPanel.cs
+++ b/CodeWalker/Project/Panels/GenerateLODLightsPanel.cs
@@ -90,7 +90,7 @@ namespace CodeWalker.Project.Panels
 
             var pname = NameTextBox.Text;
 
-            Task.Run(() =>
+            Task.Run(async () =>
             {
 
                 var lights = new List<Light>();
@@ -103,12 +103,14 @@ namespace CodeWalker.Project.Panels
                         if (ent.Archetype == null) continue;
 
                         bool waiting = false;
-                        var dwbl = gameFileCache.TryGetDrawable(ent.Archetype, out waiting);
+                        DrawableBase dwbl = null;
+
+                        (dwbl, waiting) = await gameFileCache.TryGetDrawableAsync(ent.Archetype);
                         while (waiting)
                         {
-                            dwbl = gameFileCache.TryGetDrawable(ent.Archetype, out waiting);
+                            (dwbl, waiting) = await gameFileCache.TryGetDrawableAsync(ent.Archetype);
+
                             UpdateStatus("Waiting for " + ent.Archetype.AssetName + " to load...");
-                            Thread.Sleep(20);
                         }
                         UpdateStatus("Adding lights from " + ent.Archetype.Name + "...");
                         if (dwbl != null)


### PR DESCRIPTION
this drastically speeds up the time spent loading assets when generating LOD lights