### PR TITLE
tweak(build): Copy built files into single folder

### DIFF
--- a/CodeWalker.Core/CodeWalker.Core.csproj
+++ b/CodeWalker.Core/CodeWalker.Core.csproj
@@ -26,4 +26,8 @@
     </None>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy &quot;$(TargetDir)*&quot; &quot;$(SolutionDir)Build&quot;  /s /i /Y" />
+  </Target>
+
 </Project>

--- a/CodeWalker.ErrorReport/CodeWalker.ErrorReport.csproj
+++ b/CodeWalker.ErrorReport/CodeWalker.ErrorReport.csproj
@@ -8,4 +8,8 @@
     <AssemblyName>CodeWalker Error Report Tool</AssemblyName>
   </PropertyGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy &quot;$(TargetDir)*&quot; &quot;$(SolutionDir)Build&quot;  /s /i /Y" />
+  </Target>
+
 </Project>

--- a/CodeWalker.ModManager/CodeWalker.ModManager.csproj
+++ b/CodeWalker.ModManager/CodeWalker.ModManager.csproj
@@ -41,4 +41,8 @@
     </None>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy &quot;$(TargetDir)*&quot; &quot;$(SolutionDir)Build&quot;  /s /i /Y" />
+  </Target>
+
 </Project>

--- a/CodeWalker.Peds/CodeWalker.Peds.csproj
+++ b/CodeWalker.Peds/CodeWalker.Peds.csproj
@@ -19,4 +19,8 @@
     <ProjectReference Include="..\CodeWalker\CodeWalker.csproj" />
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy &quot;$(TargetDir)*&quot; &quot;$(SolutionDir)Build&quot;  /s /i /Y" />
+  </Target>
+
 </Project>

--- a/CodeWalker.RPFExplorer/CodeWalker.RPFExplorer.csproj
+++ b/CodeWalker.RPFExplorer/CodeWalker.RPFExplorer.csproj
@@ -20,4 +20,8 @@
     <ProjectReference Include="..\CodeWalker\CodeWalker.csproj" />
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy &quot;$(TargetDir)*&quot; &quot;$(SolutionDir)Build&quot;  /s /i /Y" />
+  </Target>
+
 </Project>

--- a/CodeWalker.Vehicles/CodeWalker.Vehicles.csproj
+++ b/CodeWalker.Vehicles/CodeWalker.Vehicles.csproj
@@ -19,4 +19,8 @@
     <ProjectReference Include="..\CodeWalker\CodeWalker.csproj" />
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy &quot;$(TargetDir)*&quot; &quot;$(SolutionDir)Build&quot;  /s /i /Y" />
+  </Target>
+
 </Project>

--- a/CodeWalker.WinForms/CodeWalker.WinForms.csproj
+++ b/CodeWalker.WinForms/CodeWalker.WinForms.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="SharpDX.Mathematics" Version="4.2.0" />
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy &quot;$(TargetDir)*&quot; &quot;$(SolutionDir)Build&quot;  /s /i /Y" />
+  </Target>
+
 </Project>

--- a/CodeWalker/CodeWalker.csproj
+++ b/CodeWalker/CodeWalker.csproj
@@ -51,4 +51,8 @@
     </None>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy &quot;$(TargetDir)*&quot; &quot;$(SolutionDir)Build&quot;  /s /i /Y" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
this helps save some headache when building codewalker so all the different exes and dlls are copied into a single folder, instead of needing to do it manually