### PR TITLE
feature: Only reload specific train file on clone track node

### DIFF
--- a/CodeWalker/Project/Panels/ProjectExplorerPanel.cs
+++ b/CodeWalker/Project/Panels/ProjectExplorerPanel.cs
@@ -601,30 +601,46 @@ namespace CodeWalker.Project.Panels
 
 
         }
-        private void LoadTrainTrackTreeNodes(TrainTrack track, TreeNode node)
+        public async Task LoadTrainTrackTreeNodes(TrainTrack track, TreeNode node)
         {
             if (track == null) return;
 
             if (!string.IsNullOrEmpty(node.Name)) return; //named nodes are eg Nodes
 
-            node.Nodes.Clear();
-
-
-
-            if ((track.Nodes != null) && (track.Nodes.Count > 0))
+            await Task.Run(() =>
             {
-                var nodesnode = node.Nodes.Add("Nodes (" + track.Nodes.Count.ToString() + ")");
-                nodesnode.Name = "Nodes";
-                nodesnode.Tag = track;
-                var nodes = track.Nodes;
-                for (int i = 0; i < nodes.Count; i++)
+                // Invoke the method on the form's thread.
+                ProjectForm.Invoke((MethodInvoker)delegate
                 {
-                    var ynode = nodes[i];
-                    var tnode = nodesnode.Nodes.Add(ynode.ToString());
-                    tnode.Tag = ynode;
-                }
-            }
+                    node.Nodes.Clear();
+                });
 
+                if ((track.Nodes != null) && (track.Nodes.Count > 0))
+                {
+                    TreeNode nodesnode = null;
+                    ProjectForm.Invoke((MethodInvoker)delegate
+                    {
+                        nodesnode = node.Nodes.Add("Nodes (" + track.Nodes.Count.ToString() + ")");
+                        nodesnode.Name = "Nodes";
+                        nodesnode.Tag = track;
+                    });
+
+                    var nodes = track.Nodes;
+
+                    TreeNode[] tempList = new TreeNode[track.Nodes.Count];
+                    for (int i = 0; i < nodes.Count; i++)
+                    {
+                        var ynode = nodes[i];
+                        tempList[i] = new TreeNode(ynode.ToString());
+                        tempList[i].Tag = ynode;
+                    }
+
+                    ProjectForm.Invoke((MethodInvoker)delegate
+                    {
+                        nodesnode.Nodes.AddRange(tempList);
+                    });
+                }
+            });
         }
         private void LoadScenarioTreeNodes(YmtFile ymt, TreeNode node)
         {

--- a/CodeWalker/Project/ProjectForm.cs
+++ b/CodeWalker/Project/ProjectForm.cs
@@ -629,6 +629,7 @@ namespace CodeWalker.Project
             if (CurrentMulti != null)
             {
                 ShowEditMultiPanel(promote);
+                return;
             }
             else if (CurrentMloEntity != null)
             {
@@ -5213,10 +5214,22 @@ namespace CodeWalker.Project
 
             if (selectNew)
             {
-                LoadProjectTree();
-                ProjectExplorer?.TrySelectTrainNodeTreeNode(n);
                 CurrentTrainNode = n;
-                ShowEditTrainNodePanel(false);
+
+                var trainTrackNodeTreeNode = ProjectExplorer?.FindTrainTrackTreeNode(n.Track);
+                if (trainTrackNodeTreeNode != null) {
+                    ProjectExplorer?.LoadTrainTrackTreeNodes(n.Track, trainTrackNodeTreeNode).ContinueWith(delegate
+                        {
+                            ProjectExplorer?.TrySelectTrainNodeTreeNode(n);
+                            ShowEditTrainNodePanel(false);
+
+                        }, TaskContinuationOptions.ExecuteSynchronously);
+                } else
+                {
+                    LoadProjectTree();
+                    ProjectExplorer?.TrySelectTrainNodeTreeNode(n);
+                    ShowEditTrainNodePanel(false);
+                }
             }
 
 


### PR DESCRIPTION
Allow LoadTrainTrackTreeNodes to be called when cloning the track node in a background thread.
Adds all nodes to the UI at once, instead of each time; improves UI responsiveness/time.

I cant remember the speed increase, but IIRC it was like 3-5s to 500-850ms "lag"/render lock