### PR TITLE
Fixes: "Mipmap not found in texture" exception for textures with a height that isn't a multiple of 4 but is compressed.

### DIFF
--- a/CodeWalker.Core/GameFiles/Resources/Texture.cs
+++ b/CodeWalker.Core/GameFiles/Resources/Texture.cs
@@ -707,6 +707,8 @@ namespace CodeWalker.GameFiles
                 len += slicePitch;
                 div *= 2;
             }
+            
+            Console.WriteLine(len * Depth);
             return len * Depth;
         }
         public ushort CalculateStride()
@@ -1098,6 +1100,13 @@ namespace CodeWalker.GameFiles
                 int Height = Convert.ToInt32(parameters[2]);
                 int Levels = Convert.ToInt32(parameters[3]);
                 int Stride = Convert.ToInt32(parameters[4]);
+
+                bool compressed = DDSIO.DXTex.IsCompressed(DDSIO.GetDXGIFormat((TextureFormat)format));
+
+                if (compressed && Height % 4 != 0)
+                {
+                    Height = Math.Max(1, (Height + 3) & ~3);
+                }
 
                 int fullLength = 0;
                 int length = Stride * Height;


### PR DESCRIPTION
The DDS specification technically does not allow textures that have any dimensions that is not a multiple of 4, though many programs will allow it anyways by filling out the extra blocks with bogus data. The game seems to support this but CodeWalker has been unable to display these for a long time due to not loading the full image data in these circumstances. This PR aims to fix this by taking the height and adjusting to the next multiple of 4 to ensure all image data is loaded. The extra loaded blocks will later be discarded anyways.