### PR TITLE
[Fix] Fixes compressed DDS files with sizes which aren't divisble by 4, non-square compressed texture mipmaps, and ATI2 textures saved by OpenIV

### DIFF
--- a/CodeWalker.Core/GameFiles/Resources/Texture.cs
+++ b/CodeWalker.Core/GameFiles/Resources/Texture.cs
@@ -1113,6 +1113,9 @@ namespace CodeWalker.GameFiles
                 {
                     height = Math.Max(1, (height + 3) / 4);
                 }
+
+                int minimumLengthPerMip = DDSIO.DXTex.BitsPerPixel(DDSIO.GetDXGIFormat((TextureFormat)format)) *
+                    (compressed ? 16 : 1) / 8;
                 
                 int fullLength = 0;
                 int length = stride * height;
@@ -1147,9 +1150,8 @@ namespace CodeWalker.GameFiles
                     // Compressed texture mipmaps should never contain less than 1 4x4 block (16 pixels)
                     // so length should be constrained to never be less than bits per pixel multiplied by 16 pixels and 
                     // divided by 8 to get block length in bytes. Uncompressed texture mipmaps should never contain less
-                    // than 1 pixel's worth of data. 
-                    length = Math.Max(DDSIO.DXTex.BitsPerPixel(DDSIO.GetDXGIFormat((TextureFormat)format)) * 
-                        (compressed ? 16 : 1)/8, length);
+                    // than 1 pixel's worth of data.
+                    length = Math.Max(minimumLengthPerMip, length);
                 }
 
                 FullData = reader.ReadBytes(fullLength);

--- a/CodeWalker.Core/GameFiles/Resources/Texture.cs
+++ b/CodeWalker.Core/GameFiles/Resources/Texture.cs
@@ -1104,7 +1104,7 @@ namespace CodeWalker.GameFiles
 
                 if (compressed && Height % 4 != 0)
                 {
-                    Height = Math.Max(1, (Height + 3) & ~3);
+                    Height = Math.Max(4, (Height + 3) & ~3);
                 }
 
                 int fullLength = 0;

--- a/CodeWalker.Core/GameFiles/Resources/Texture.cs
+++ b/CodeWalker.Core/GameFiles/Resources/Texture.cs
@@ -708,7 +708,6 @@ namespace CodeWalker.GameFiles
                 div *= 2;
             }
             
-            Console.WriteLine(len * Depth);
             return len * Depth;
         }
         public ushort CalculateStride()

--- a/CodeWalker.Core/GameFiles/Resources/Texture.cs
+++ b/CodeWalker.Core/GameFiles/Resources/Texture.cs
@@ -707,6 +707,8 @@ namespace CodeWalker.GameFiles
                 len += slicePitch;
                 div *= 2;
             }
+            
+            Console.WriteLine(len * Depth);
             return len * Depth;
         }
         public ushort CalculateStride()
@@ -1098,6 +1100,13 @@ namespace CodeWalker.GameFiles
                 int Height = Convert.ToInt32(parameters[2]);
                 int Levels = Convert.ToInt32(parameters[3]);
                 int Stride = Convert.ToInt32(parameters[4]);
+
+                bool compressed = DDSIO.DXTex.IsCompressed(DDSIO.GetDXGIFormat((TextureFormat)format));
+
+                if (compressed && Height % 4 != 0)
+                {
+                    Height = Math.Max(1, (Height + 3) & ~3);
+                }
 
                 int fullLength = 0;
                 int length = Stride * Height;

--- a/CodeWalker.Core/GameFiles/Utils/DDSIO.cs
+++ b/CodeWalker.Core/GameFiles/Utils/DDSIO.cs
@@ -544,8 +544,10 @@ namespace CodeWalker.Utils
             int add = 0;
             for (int i = 0; i < img.MipMapLevels; i++)
             {
-                images[i].width = img.Width / div;
-                images[i].height = img.Height / div;
+                // Prevent width or height from becoming zero. One divided by anything will be < 1 which when cast to an
+                // int will be truncated to 0.
+                images[i].width = Math.Max(1, img.Width / div);
+                images[i].height = Math.Max(1, img.Height / div);
                 images[i].format = format; //(DXGI_FORMAT)img.Format;
                 images[i].pixels = buf + add;
 
@@ -2701,32 +2703,33 @@ namespace CodeWalker.Utils
                         r = (byte)(((6 - rIndex) * r0 + (rIndex - 1) * r1) / 5);
                     }
 
-
+                    // Fixed copy and paste error? Most of these 'g's below were 'r's, which caused BC5 (ATI2) textures
+                    // to not have correct colors.
                     byte g = 255;
                     uint gIndex = (uint)((gMask >> 3 * (4 * blockY + blockX)) & 0x07);
                     if (gIndex == 0)
                     {
-                        r = r0;
+                        g = g0;
                     }
                     else if (gIndex == 1)
                     {
-                        r = r1;
+                        g = g1;
                     }
-                    else if (r0 > r1)
+                    else if (g0 > g1)
                     {
-                        r = (byte)(((8 - gIndex) * r0 + (gIndex - 1) * r1) / 7);
+                        g = (byte)(((8 - gIndex) * g0 + (gIndex - 1) * g1) / 7);
                     }
                     else if (gIndex == 6)
                     {
-                        r = 0;
+                        g = 0;
                     }
                     else if (gIndex == 7)
                     {
-                        r = 0xff;
+                        g = 0xff;
                     }
                     else
                     {
-                        r = (byte)(((6 - gIndex) * r0 + (gIndex - 1) * r1) / 5);
+                        g = (byte)(((6 - gIndex) * g0 + (gIndex - 1) * g1) / 5);
                     }
 
 

--- a/CodeWalker/Forms/YtdForm.cs
+++ b/CodeWalker/Forms/YtdForm.cs
@@ -153,8 +153,10 @@ namespace CodeWalker.Forms
             {
                 int cmip = Math.Min(Math.Max(mip, 0), tex.Levels - 1);
                 byte[] pixels = DDSIO.GetPixels(tex, cmip);
-                int w = tex.Width >> cmip;
-                int h = tex.Height >> cmip;
+                // Certain mipmap dimension reduction chains may lead this to become zero, so it should be clamped to be
+                // one at minimum.
+                int w = Math.Max(1, tex.Width >> cmip);
+                int h = Math.Max(1, tex.Height >> cmip);
                 Bitmap bmp = new Bitmap(w, h, PixelFormat.Format32bppArgb);
 
                 if (pixels != null)


### PR DESCRIPTION
This PR would patch several additional DDS errors I found. I've done my best to comment with good explanations in the code why the changes I made were made. Prior to merge, if this does get merged I can go remove all those comments if that is desired. As for some samples of files that you can test to see before and after see the following (these errors were all found by going through the YTDs from PLOKS Car pack so all examples are from there).

- [tltypes.ytd](https://github.com/PLOKMJNB/FiveM-Civ-Car-Pack/blob/master/PLOKS_CARS/stream/%5BACURA%5D/tltypes/tltypes.ytd) - specifically the texture `generic_leather2_n`, texture has an incorrect stride baked into the YTD and the BC5 decompression method had a bit of an apparent copy/paste mistake.
- [q820.ytd](https://github.com/PLOKMJNB/FiveM-Civ-Car-Pack/blob/master/PLOKS_CARS/stream/%5BAUDI%5D/q820/q820.ytd) - specifically the textures `1_leathern` and `airbag_opac1`, both files had issues loading the final mipmap prior to these patches.
- [r820.ytd](https://github.com/PLOKMJNB/FiveM-Civ-Car-Pack/blob/master/PLOKS_CARS/stream/%5BAUDI%5D/r820/r820.ytd) - specifically `r8_005_diff` had a similar issue with the last mipmap level.