### PR TITLE
Auto-calculate stride value on read to fix potential incorrect values in data textures

### DIFF
--- a/CodeWalker.Core/GameFiles/Resources/Texture.cs
+++ b/CodeWalker.Core/GameFiles/Resources/Texture.cs
@@ -714,7 +714,7 @@ namespace CodeWalker.GameFiles
             if (Format == 0) return 0;
             var dxgifmt = DDSIO.GetDXGIFormat(Format);
             DDSIO.DXTex.ComputePitch(dxgifmt, Width, Height, out var rowPitch, out var slicePitch, 0);
-            return (ushort)rowPitch;
+            return (ushort)(rowPitch / 4);
         }
         public TextureFormat GetLegacyFormat(TextureFormatG9 format)
         {
@@ -938,6 +938,7 @@ namespace CodeWalker.GameFiles
                 this.Unknown_88h = reader.ReadUInt32();
                 this.Unknown_8Ch = reader.ReadUInt32();
 
+                this.Stride = CalculateStride();
                 // read reference data
                 this.Data = reader.ReadBlockAt<TextureData>(this.DataPointer, this.Format, this.Width, this.Height, this.Levels, this.Stride);
 

--- a/CodeWalker.Core/GameFiles/Resources/Texture.cs
+++ b/CodeWalker.Core/GameFiles/Resources/Texture.cs
@@ -712,9 +712,12 @@ namespace CodeWalker.GameFiles
         public ushort CalculateStride()
         {
             if (Format == 0) return 0;
-            var dxgifmt = DDSIO.GetDXGIFormat(Format);
+            bool isCompressed;
+            var dxgifmt = DDSIO.GetDXGIFormat(Format, out isCompressed);
             DDSIO.DXTex.ComputePitch(dxgifmt, Width, Height, out var rowPitch, out var slicePitch, 0);
-            return (ushort)(rowPitch / 4);
+            // For compressed formats (BC/DXT): convert bytes to DWORD units (divide by 4)
+            // For uncompressed formats: return the original row pitch in bytes
+            return isCompressed ? (ushort)(rowPitch / 4) : (ushort)(rowPitch);
         }
         public TextureFormat GetLegacyFormat(TextureFormatG9 format)
         {
@@ -938,6 +941,7 @@ namespace CodeWalker.GameFiles
                 this.Unknown_88h = reader.ReadUInt32();
                 this.Unknown_8Ch = reader.ReadUInt32();
 
+                // auto-calculate stride value to fix potential incorrect values in data textures
                 this.Stride = CalculateStride();
                 // read reference data
                 this.Data = reader.ReadBlockAt<TextureData>(this.DataPointer, this.Format, this.Width, this.Height, this.Levels, this.Stride);

--- a/CodeWalker.Core/GameFiles/Utils/DDSIO.cs
+++ b/CodeWalker.Core/GameFiles/Utils/DDSIO.cs
@@ -500,18 +500,19 @@ namespace CodeWalker.Utils
             return format;
         }
 
-        public static DXGI_FORMAT GetDXGIFormat(TextureFormat f)
+        public static DXGI_FORMAT GetDXGIFormat(TextureFormat f, out bool isCompressed)
         {
             var format = DXGI_FORMAT.DXGI_FORMAT_UNKNOWN;
+            isCompressed = false;
             switch (f)
             {
                 // compressed
-                case TextureFormat.D3DFMT_DXT1: format = DXGI_FORMAT.DXGI_FORMAT_BC1_UNORM; break;
-                case TextureFormat.D3DFMT_DXT3: format = DXGI_FORMAT.DXGI_FORMAT_BC2_UNORM; break;
-                case TextureFormat.D3DFMT_DXT5: format = DXGI_FORMAT.DXGI_FORMAT_BC3_UNORM; break;
-                case TextureFormat.D3DFMT_ATI1: format = DXGI_FORMAT.DXGI_FORMAT_BC4_UNORM; break;
-                case TextureFormat.D3DFMT_ATI2: format = DXGI_FORMAT.DXGI_FORMAT_BC5_UNORM; break;
-                case TextureFormat.D3DFMT_BC7: format = DXGI_FORMAT.DXGI_FORMAT_BC7_UNORM; break;
+                case TextureFormat.D3DFMT_DXT1: format = DXGI_FORMAT.DXGI_FORMAT_BC1_UNORM; isCompressed = true; break;
+                case TextureFormat.D3DFMT_DXT3: format = DXGI_FORMAT.DXGI_FORMAT_BC2_UNORM; isCompressed = true; break;
+                case TextureFormat.D3DFMT_DXT5: format = DXGI_FORMAT.DXGI_FORMAT_BC3_UNORM; isCompressed = true; break;
+                case TextureFormat.D3DFMT_ATI1: format = DXGI_FORMAT.DXGI_FORMAT_BC4_UNORM; isCompressed = true; break;
+                case TextureFormat.D3DFMT_ATI2: format = DXGI_FORMAT.DXGI_FORMAT_BC5_UNORM; isCompressed = true; break;
+                case TextureFormat.D3DFMT_BC7: format = DXGI_FORMAT.DXGI_FORMAT_BC7_UNORM; isCompressed = true; break;
 
                 // uncompressed
                 case TextureFormat.D3DFMT_A1R5G5B5: format = DXGI_FORMAT.DXGI_FORMAT_B5G5R5A1_UNORM; break;
@@ -522,6 +523,12 @@ namespace CodeWalker.Utils
                 case TextureFormat.D3DFMT_X8R8G8B8: format = DXGI_FORMAT.DXGI_FORMAT_B8G8R8X8_UNORM; break;
             }
             return format;
+        }
+
+        public static DXGI_FORMAT GetDXGIFormat(TextureFormat f)
+        {
+            bool isCompressed;
+            return GetDXGIFormat(f, out isCompressed);
         }
 
         private static ImageStruct GetImageStruct(Texture texture, DXGI_FORMAT format)


### PR DESCRIPTION

Update the CalculateStride method:
- For compressed formats (BC/DXT): convert bytes to DWORD units (divide by 4)
- For uncompressed formats: return the original row pitch in bytes

Features:
- Calculated stride values ​​now match vanilla source data for all .ytd files
- Fixes errors of reading and writing ATI2 textures with incorrect Strides (Saved OpenIV)