### PR TITLE
fix(lodlights): Fix bound box calculation for lodlights

### DIFF
--- a/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs
+++ b/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs
@@ -2234,14 +2234,7 @@ namespace CodeWalker.GameFiles
             }
             if (lightAttrs == null) return;
 
-            var abmin = Vector3.Min(Archetype.BBMin, db.BoundingBoxMin);
-            var abmax = Vector3.Max(Archetype.BBMax, db.BoundingBoxMax);
-            if (b != null)
-            {
-                abmin = Vector3.Min(abmin, b.BoxMin);
-                abmax = Vector3.Max(abmax, b.BoxMax);
-            }
-            var bb = new BoundingBox(abmin, abmax).Transform(Position, Orientation, Scale);
+            var bb = new BoundingBox(Archetype.BBMin, Archetype.BBMax).Transform(Position, Orientation, Scale);
             var ints = new uint[7];
             ints[0] = (uint)(bb.Minimum.X * 10.0f);
             ints[1] = (uint)(bb.Minimum.Y * 10.0f);


### PR DESCRIPTION
currently it uses the drawable bounds and the archetype bounds leading to incidents where the light hash is incorrect and the lodlight is not linked to the HD one