### PR TITLE
tweak(lodlight): only set corona intensity if size or intensity is not 0

### DIFF
--- a/CodeWalker/Project/Panels/GenerateLODLightsPanel.cs
+++ b/CodeWalker/Project/Panels/GenerateLODLightsPanel.cs
@@ -168,7 +168,11 @@ namespace CodeWalker.Project.Panels
                                     light.hash = h;
                                     light.coneInnerAngle = inner;
                                     light.coneOuterAngleOrCapExt = outer;
-                                    if (la.CoronaSize != 0)
+                                    if (la.CoronaSize == 0 || la.CoronaIntensity == 0)
+                                    {
+                                        light.coronaIntensity = 0;
+                                    }
+                                    else
                                     {
                                         light.coronaIntensity = (byte)(la.CoronaIntensity * 6);
                                     }


### PR DESCRIPTION
this fixes some instances where the Size would be 1 or so, but the intensity being 0, this should mean there is no corona, but the generator previously only checked if the size wasnt 0.