### PR TITLE
Fix SetOrientation

### DIFF
--- a/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs
+++ b/CodeWalker.Core/GameFiles/FileTypes/YmapFile.cs
@@ -1979,6 +1979,8 @@ namespace CodeWalker.GameFiles
                 Quaternion inv = Quaternion.Normalize(Quaternion.Invert(rel));
                 Orientation = ori;
                 _CEntityDef.rotation = inv.ToVector4();
+                UpdateBB();
+                UpdateMloArchetype();
             }
             else
             {
@@ -1992,6 +1994,7 @@ namespace CodeWalker.GameFiles
                     Quaternion inv = inverse ? ori : Quaternion.Normalize(Quaternion.Invert(ori));
                     _CEntityDef.rotation = inv.ToVector4();
                 }
+                UpdateBB();
             }
 
             if (MloInstance != null)
@@ -2000,7 +2003,6 @@ namespace CodeWalker.GameFiles
                 MloInstance.UpdateEntities();
             }
 
-            UpdateBB();
             UpdateWidgetPosition();
             UpdateWidgetOrientation();
         }
@@ -2020,6 +2022,8 @@ namespace CodeWalker.GameFiles
                     MloRefOrientation = Quaternion.Invert(MloRefOrientation);
                 }
                 Orientation = Quaternion.Multiply(MloParent.Orientation, MloRefOrientation);
+                UpdateBB();
+                UpdateMloArchetype();
             }
             else
             {
@@ -2031,6 +2035,7 @@ namespace CodeWalker.GameFiles
                         Orientation = Quaternion.Invert(Orientation);
                     }
                 }
+                UpdateBB();
             }
 
             if (MloInstance != null)
@@ -2039,7 +2044,6 @@ namespace CodeWalker.GameFiles
                 MloInstance.UpdateEntities();
             }
 
-            UpdateBB();
             UpdateWidgetPosition();
             UpdateWidgetOrientation();
         }


### PR DESCRIPTION
Fixed a bug where changed entity rotation values ​​were not saved when using EntityRotationQuatBox in ytyp, but were only saved via widget rotation.