### PR TITLE
Fix exporting files with the same name lead to overwrites

### DIFF
--- a/CodeWalker/ExploreForm.cs
+++ b/CodeWalker/ExploreForm.cs
@@ -2322,8 +2322,6 @@ namespace CodeWalker
         }
 
 
-
-
         private void ViewSelected()
         {
             for (int i = 0; i < MainListView.SelectedIndices.Count; i++)
@@ -2350,6 +2348,28 @@ namespace CodeWalker
                 }
             }
         }
+
+        private string GetUniquePath(string folder, string name)
+        {
+            try
+            {
+                var baseName = Path.GetFileNameWithoutExtension(name);
+                var ext = Path.GetExtension(name);
+                var candidate = Path.Combine(folder, name);
+                int i = 1;
+                while (File.Exists(candidate))
+                {
+                    candidate = Path.Combine(folder, string.Format("{0}({1}){2}", baseName, i, ext));
+                    i++;
+                }
+                return candidate;
+            }
+            catch
+            {
+                return Path.Combine(folder, name);
+            }
+        }
+
         private void ExportXml()
         {
             var needfolder = false;//need a folder to output ytd XML to, for the texture .dds files
@@ -2412,7 +2432,7 @@ namespace CodeWalker
                         var xml = GetFileXml(file, out var newfn, folderpath, errorAction);
                         if (string.IsNullOrEmpty(xml)) continue;
 
-                        var path = folderpath + newfn;
+                        var path = GetUniquePath(folderpath, newfn);
                         try
                         {
                             File.WriteAllText(path, xml);
@@ -2477,7 +2497,7 @@ namespace CodeWalker
                     var file = CurrentFiles[idx];
                     if ((file.Folder == null) || (file.Folder.RpfFile != null))
                     {
-                        var path = folderpath + file.Name;
+                        var path = GetUniquePath(folderpath, file.Name);
                         try
                         {
                             var data = GetFileDataCompressResources(file);
@@ -2548,7 +2568,7 @@ namespace CodeWalker
                     var file = CurrentFiles[idx];
                     if (file.Folder == null)
                     {
-                        var path = folderpath + file.Name;
+                        var path = GetUniquePath(folderpath, file.Name);
                         var data = GetFileData(file);
                         if (data == null)
                         {
@@ -2586,7 +2606,7 @@ namespace CodeWalker
             {
                 if ((file.Folder == null) || (file.Folder.RpfFile != null))
                 {
-                    var path = folderpath + file.Name;
+                    var path = GetUniquePath(folderpath, file.Name);
                     try
                     {
                         var data = GetFileDataCompressResources(file);
@@ -3958,7 +3978,7 @@ namespace CodeWalker
                 try
                 {
                     var data = GetFileDataCompressResources(file);
-                    var filename = Path.Combine(outdir, file.Name);
+                    var filename = GetUniquePath(outdir, file.Name);
                     File.WriteAllBytes(filename, data);
                     if (addfilename)
                     {


### PR DESCRIPTION
When searching for files, they all have the same name so exporting multiple ones would lead to only one being created and being overwritten everytime. This PR fixes the issue by adding a (x) to the filename like shown in the screenshot : 
<img width="816" height="184" alt="image" src="https://github.com/user-attachments/assets/03997b66-f170-47a6-b69b-d9d99b8449c7" />
