### PR TITLE
Fixed directories not deleting if items exist inside.

### DIFF
--- a/CodeWalker/ExploreForm.cs
+++ b/CodeWalker/ExploreForm.cs
@@ -3379,7 +3379,7 @@ namespace CodeWalker
                     //delete an item in the filesystem.
                     if ((item.Folder != null) && (item.Folder.RpfFile == null))
                     {
-                        Directory.Delete(item.FullPath);
+                        Directory.Delete(item.FullPath, true);
                     }
                     else
                     {


### PR DESCRIPTION
Previously when trying to delete a directory, it would just throw an error (even after passing messagebox contents inside warning).